### PR TITLE
Round robin arbitration + arbitration updates

### DIFF
--- a/sim/functional/arbiter_rr/Makefile
+++ b/sim/functional/arbiter_rr/Makefile
@@ -1,0 +1,31 @@
+export PYTHON_BIN=/usr/bin/python3
+export SHELL=/bin/bash
+
+export TOPLEVEL_LANG ?= verilog
+SWITCH_VER_DIR=$(shell git rev-parse --show-toplevel)/srcs/switch/
+NOC_VER_DIR=$(shell git rev-parse --show-toplevel)/srcs/noc
+
+export DEBUG_ATTACH ?=0
+#export COVERAGE?=0
+LOG_DEBUG?=0
+
+# files
+# VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/static_priority_arbiter.v
+# VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/matrix_arbiter.v
+VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/round_robin.v
+
+# Specifies essentials of the DUT and the cocotb TB
+TOPLEVEL := round_robin_arb
+MODULE   := test
+SIM      ?= icarus
+
+export IN_N         ?= 2
+
+
+COCOTB_HDL_TIMEUNIT      = 1ns
+COCOTB_HDL_TIMEPRECISION = 1ps
+
+COMPILE_ARGS += -P $(TOPLEVEL).IN_N=$(IN_N)
+COMPILE_ARGS += -D SIMULATION=1
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/sim/functional/arbiter_rr/test.py
+++ b/sim/functional/arbiter_rr/test.py
@@ -1,0 +1,37 @@
+from secrets import randbits
+import cocotb
+from cocotb.clock import Clock
+from cocotb.result import TestSuccess
+from cocotb.triggers import ClockCycles, RisingEdge, ReadWrite, ReadOnly, FallingEdge
+
+import os
+
+def blip(signal, val):
+    signal.setimmediatevalue(val)
+
+@cocotb.test()
+async def simple_test(dut):
+    cocotb.log.info("----- Simulation Started!")
+    clk_obj = Clock(dut.clk_i, 10)
+    clk = cocotb.fork(clk_obj.start())
+    dut.rst_ni.setimmediatevalue(0)
+    await ClockCycles(dut.clk_i, 10)
+    dut.rst_ni.setimmediatevalue(1)
+    
+    await RisingEdge(dut.clk_i)
+    await ReadWrite()
+
+    n = int(os.environ["IN_N"])
+
+    blip(dut.req_i, randbits(n))
+    for i in range(10):
+        await RisingEdge(dut.clk_i)
+        await ReadOnly()
+        print(f"{dut.priority_robin.value} AND {dut.req_i.value} => {dut.grant_w.value} : {dut.grant_o.value.integer}")
+        await FallingEdge(dut.clk_i)
+        await ReadWrite()
+        blip(dut.req_i, randbits(n))
+
+    await ClockCycles(dut.clk_i, 10)
+    raise TestSuccess("Sim finished sucessfully")
+

--- a/sim/functional/mesh_wh_xy_noc/Makefile
+++ b/sim/functional/mesh_wh_xy_noc/Makefile
@@ -17,6 +17,8 @@ LOG_DEBUG?=0
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/constants.v
 VERILOG_SOURCES += $(COMPONENT_VER_DIR)/circ_fifo.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/matrix_arbiter.v
+VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/round_robin.v
+VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/static_priority_arbiter.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/crossbars/nxn_parrallel_crossbar.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/routers/xy_router.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/virtual_channels/virtual_channel.v
@@ -41,6 +43,7 @@ export CHANNEL_W            ?= 8
 export FLIT_ID_W            ?= 2
 export NODE_RADIX           ?= 5
 export NODE_BUFFER_DEPTH_W  ?= 2
+export ARB_TYPE             ?= 0
 export CLK_PERIOD           ?= 10
 
 COCOTB_HDL_TIMEUNIT       = 1ns
@@ -53,6 +56,7 @@ COMPILE_ARGS += -P $(TOPLEVEL).FLIT_ID_W=$(FLIT_ID_W)
 COMPILE_ARGS += -P $(TOPLEVEL).NODE_RADIX=$(NODE_RADIX)
 COMPILE_ARGS += -P $(TOPLEVEL).CHANNEL_W=$(CHANNEL_W)
 COMPILE_ARGS += -P $(TOPLEVEL).NODE_BUFFER_DEPTH_W=$(NODE_BUFFER_DEPTH_W)
+COMPILE_ARGS += -P $(TOPLEVEL).ARB_TYPE=$(ARB_TYPE)
 COMPILE_ARGS += -P $(TOPLEVEL).CLK_PERIOD=$(CLK_PERIOD)
 COMPILE_ARGS += -D SIMULATION=1
 ifeq ($(LOG_DEBUG), 1)

--- a/sim/functional/mesh_wh_xy_noc/noc.py
+++ b/sim/functional/mesh_wh_xy_noc/noc.py
@@ -31,7 +31,8 @@ class WHNoCTB:
       "row_n": int(os.environ["ROW_N"]),
       "col_m": int(os.environ["COL_M"]),
       "channel_w": int(os.environ["CHANNEL_W"]),
-      "node_buffer_depth_w": int(os.environ["NODE_BUFFER_DEPTH_W"])
+      "node_buffer_depth_w": int(os.environ["NODE_BUFFER_DEPTH_W"]),
+      "arb_type": int(os.environ["ARB_TYPE"])
     }
 
     assert self.dut.NODE_RADIX == self.config["node_radix"], "Bad Value"
@@ -40,6 +41,7 @@ class WHNoCTB:
     assert self.dut.ROW_N == self.config["row_n"], "Bad Value"
     assert self.dut.COL_M == self.config["col_m"], "Bad Value"
     assert self.dut.CHANNEL_W == self.config["channel_w"], "Bad Value"
+    assert self.dut.ARB_TYPE == self.config["arb_type"], "Bad Value"
 
     self.log.info(f"Created NocTB! {self.config}")
     self.drv = ChanDriver(dut, "in_chan", dut.clk_i, -1, self.config, log_lvl)
@@ -290,7 +292,7 @@ class WHNoCTB:
 
         self.noc_metrics.print()
 
-        metrics_filepath = METRICS_FILENAME + f"_{self.noc_metrics.plen}" + ".json"
+        metrics_filepath = METRICS_FILENAME + f"_plen{self.noc_metrics.plen}" + ".json"
         self.json_dump(self.noc_metrics.json_gen(), metrics_filepath)
 
         await ClockCycles(self.dut.clk_i, 10)

--- a/sim/functional/mesh_wh_xy_noc/plot_json.py
+++ b/sim/functional/mesh_wh_xy_noc/plot_json.py
@@ -6,6 +6,8 @@ import argparse
 from pathlib import Path
 from pprint import pprint as pp
 
+#
+
 def extract_rows(df, regex):
     tmp_dict = {}
     for row in df.iterrows():

--- a/sim/functional/mesh_wh_xy_noc/run_and_verify.py
+++ b/sim/functional/mesh_wh_xy_noc/run_and_verify.py
@@ -6,7 +6,7 @@ from utils.rav import *
 from utils.logger import *
 import glob
 
-def main(tf, ps, synth, row_n, col_m, ff_depth, channel_w, regression, log_lvl) -> None:
+def main(tf, ps, synth, row_n, col_m, ff_depth, channel_w, arb_type, regression, log_lvl) -> None:
   log = get_logger(__name__, int(log_lvl))
   log.info(f"RUN {time.asctime()}")
 
@@ -14,7 +14,8 @@ def main(tf, ps, synth, row_n, col_m, ff_depth, channel_w, regression, log_lvl) 
   arguments = {"ROW_N": row_n,
                "COL_M": col_m,
                "NODE_BUFFER_DEPTH_W": ff_depth,
-               "CHANNEL_W": channel_w}
+               "CHANNEL_W": channel_w,
+               "ARB_TYPE": arb_type}
 
   if regression:
     runs = []
@@ -24,7 +25,8 @@ def main(tf, ps, synth, row_n, col_m, ff_depth, channel_w, regression, log_lvl) 
     for ri in range(2, row_max + 1):
       for ci in range(2, col_max + 1):
         arguments = {"ROW_N": row_n,
-                     "COL_M": col_m, "NODE_BUFFER_DEPTH_W": ff_depth,
+                     "COL_M": col_m, 
+                     "NODE_BUFFER_DEPTH_W": ff_depth,
                      "CHANNEL_W": channel_w}
         runs.append(simulate(log, tf, ps, synth, arguments, tcl_script))
         failed_runs += runs[-1][0]
@@ -77,6 +79,7 @@ if __name__ == '__main__':
   parser.add_argument('-col_m', default=3, help='COL_M parameter')
   parser.add_argument('-ff_depth', default=2, help='FIFO_DEPTH_W parameter')
   parser.add_argument('-channel_w', default=8, help='CHANNEL_W parameter')
+  parser.add_argument('-arb_type', default=0, help="Arbitration Type(0-matrix, 1-round robin, 2-static")
   parser.add_argument('-regression', default=0, help="IF '1' RUNS NOC simulations from 2x2 to 4x4"
                                                      " to check size problems")
   parser.add_argument('-log_lvl', default=1, help="Logging LEVEL (INFO=0, DEBUG=1)")
@@ -88,10 +91,10 @@ if __name__ == '__main__':
 
   if args.ps:
     metrics_filename = f"mesh_noc_wh_xy_postsynth_{args.row_n}_{args.col_m}" \
-                       f"_{args.ff_depth}_{args.channel_w}"
+                       f"_{args.ff_depth}_{args.channel_w}_arb{args.arb_type}"
   else:
     metrics_filename = f"mesh_noc_wh_xy_presynth_{args.row_n}_{args.col_m}" \
-                       f"_{args.ff_depth}_{args.channel_w}"
+                       f"_{args.ff_depth}_{args.channel_w}_arb{args.arb_type}"
                        
   if args.tf == 0:
     fileList = glob.glob(f'{metrics_filename}*.json')

--- a/sim/functional/mesh_wh_xy_noc/tb.sv
+++ b/sim/functional/mesh_wh_xy_noc/tb.sv
@@ -9,6 +9,7 @@ module tb
     parameter FLIT_ID_W = 2,
     parameter NODE_BUFFER_DEPTH_W = 3,
     parameter CHANNEL_W = 10,
+    parameter ARB_TYPE = 0,
     parameter CLK_PERIOD = 10
     )
   (
@@ -33,6 +34,7 @@ module tb
       $display("COL_M %d", COL_M);
       $display("NODE_BUFFER_DEPTH_W %d", NODE_BUFFER_DEPTH_W);
       $display("CHANNEL_W %d", CHANNEL_W);
+      $display("ARB_TYPE %d", ARB_TYPE);
     end
 
     reg clk_i = 1'b0;
@@ -57,7 +59,8 @@ module tb
       .FLIT_ID_W(FLIT_ID_W),
       .NODE_RADIX(NODE_RADIX),
       .CHANNEL_W(CHANNEL_W),
-      .NODE_BUFFER_DEPTH_W(NODE_BUFFER_DEPTH_W)
+      .NODE_BUFFER_DEPTH_W(NODE_BUFFER_DEPTH_W),
+      .ARB_TYPE(ARB_TYPE)
       )
     x_mesh_wh_xy_noc (
       .clk_i(clk_i),

--- a/sim/functional/mesh_wormhole_switch/Makefile
+++ b/sim/functional/mesh_wormhole_switch/Makefile
@@ -8,6 +8,8 @@ SRC_DIR=$(shell git rev-parse --show-toplevel)/srcs
 VERILOG_SOURCES = $(SRC_DIR)/switch/constants.v
 VERILOG_SOURCES += $(SRC_DIR)/components/circ_fifo.v
 VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/matrix_arbiter.v
+VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/round_robin.v
+VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/static_priority_arbiter.v
 VERILOG_SOURCES += $(SRC_DIR)/switch/allocators/allocator.v
 VERILOG_SOURCES += $(SRC_DIR)/switch/routers/xy_router.v
 VERILOG_SOURCES += $(SRC_DIR)/switch/virtual_channels/virtual_channel.v
@@ -34,6 +36,7 @@ export ROW_ADDR_W     ?= 2 # 6
 export FLIT_ID_W      ?= 2 # 7
 export FLIT_DATA_W    ?= 8 # 8
 export BUFFER_DEPTH_W ?= 2 # 9
+export ARB_TYPE       ?= 0 # 10
 
 export CLK_PERIOD     ?= 10
 
@@ -47,6 +50,7 @@ ifeq ($(SIM), icarus)
   COMPILE_ARGS += -P $(TOPLEVEL).COL_ADDR_W=$(COL_ADDR_W)          # 7
   COMPILE_ARGS += -P $(TOPLEVEL).COL_CORD=$(COL_CORD)              # 8
   COMPILE_ARGS += -P $(TOPLEVEL).BUFFER_DEPTH_W=$(BUFFER_DEPTH_W)  # 9
+  COMPILE_ARGS += -P $(TOPLEVEL).ARB_TYPE=$(ARB_TYPE)              # 10
   COMPILE_ARGS += -P $(TOPLEVEL).CLK_PERIOD=$(CLK_PERIOD)
 endif
 

--- a/sim/functional/mesh_wormhole_switch/run_and_verify.py
+++ b/sim/functional/mesh_wormhole_switch/run_and_verify.py
@@ -6,7 +6,7 @@ from utils.rav import simulate
 
 
 def main(tf, ps, synth, in_n, out_m, flit_data_w, flit_id_w, row_cord,
-         col_cord, row_addr_w, col_addr_w, buffer_depth_w, log_lvl) -> None:
+         col_cord, row_addr_w, col_addr_w, buffer_depth_w, arb_type, log_lvl) -> None:
     log = get_logger(__name__, int(log_lvl))
     log.info(f"RUN {time.asctime()}")
     log.info("----------------------------------------------------------------------------------------------------"
@@ -21,7 +21,8 @@ def main(tf, ps, synth, in_n, out_m, flit_data_w, flit_id_w, row_cord,
                  "COL_CORD": col_cord,
                  "ROW_ADDR_W": row_addr_w,
                  "COL_ADDR_W": col_addr_w,
-                 "BUFFER_DEPTH_W": buffer_depth_w}
+                 "BUFFER_DEPTH_W": buffer_depth_w,
+                 "ARB_TYPE": arb_type}
 
     run = simulate(log, tf, ps, synth, arguments, tcl_script)
     if run[0]:  # FAILED RUN
@@ -54,6 +55,7 @@ if __name__ == '__main__':
     parser.add_argument('-row_addr_w', default=2,    help='Width of Row Address(def=2)')
     parser.add_argument('-col_addr_w', default=2,    help='Width of Col Address(def=2)')
     parser.add_argument('-buffer_depth_w', default=2,    help='Buffer Depth Width(def=2)')
+    parser.add_argument('-arb_type', default=0, help="Arbitration Type(0-matrix, 1-round robin, 2-static")
     parser.add_argument('-log_lvl', default=1, help="Logging LEVEL (INFO=0, DEBUG=1)")
 
     args = parser.parse_args()

--- a/sim/functional/mesh_wormhole_switch/tb.sv
+++ b/sim/functional/mesh_wormhole_switch/tb.sv
@@ -15,6 +15,7 @@ module tb
     parameter ROW_CORD        = 0,
     parameter COL_CORD        = 0,
     parameter BUFFER_DEPTH_W  = 2,
+    parameter ARB_TYPE        = 0,
     parameter CLK_PERIOD      = 10
     )
   (
@@ -72,7 +73,8 @@ module tb
     .COL_ADDR_W(COL_ADDR_W),
     .ROW_CORD(ROW_CORD),
     .COL_CORD(COL_CORD),
-    .BUFFER_DEPTH_W(BUFFER_DEPTH_W)
+    .BUFFER_DEPTH_W(BUFFER_DEPTH_W),
+    .ARB_TYPE(ARB_TYPE)
     )
   dut_inst
   (

--- a/sim/functional/mesh_xy_noc/Makefile
+++ b/sim/functional/mesh_xy_noc/Makefile
@@ -17,6 +17,7 @@ VERILOG_SOURCES += $(SWITCH_VER_DIR)/simple_mesh_xy/switch_constants.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/simple_mesh_xy/xy_switch.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/simple_mesh_xy/control_unit.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/static_priority_arbiter.v
+VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/round_robin.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/arbiters/matrix_arbiter.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/crossbars/nxn_single_crossbar.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/routers/xy_router.v
@@ -36,6 +37,7 @@ export ROW_N        ?= 4
 export COL_M        ?= 4
 export PCKT_DATA_W  ?= 8
 export FIFO_DEPTH_W ?= 8
+export ARB_TYPE     ?= 0
 
 # Clock period in NS
 export CLK_PERIOD        ?= 10
@@ -49,6 +51,7 @@ COMPILE_ARGS += -P $(TOPLEVEL).COL_M=$(COL_M)
 COMPILE_ARGS += -P $(TOPLEVEL).PCKT_DATA_W=$(PCKT_DATA_W)
 COMPILE_ARGS += -P $(TOPLEVEL).FIFO_DEPTH_W=$(FIFO_DEPTH_W)
 COMPILE_ARGS += -P $(TOPLEVEL).CLK_PERIOD=$(CLK_PERIOD)
+COMPILE_ARGS += -P $(TOPLEVEL).ARB_TYPE=$(ARB_TYPE)
 COMPILE_ARGS += -D SIMULATION=1
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/sim/functional/mesh_xy_noc/run_and_verify.py
+++ b/sim/functional/mesh_xy_noc/run_and_verify.py
@@ -4,7 +4,7 @@ import argparse
 from utils.rav import *
 
 
-def main(tf, ps, synth, row_n, col_m, ff_depth, pckt_w, regression, log_lvl) -> None:
+def main(tf, ps, synth, row_n, col_m, ff_depth, pckt_w, arb_type, regression, log_lvl) -> None:
   log = get_logger(__name__, int(log_lvl))
   log.info(f"RUN {time.asctime()}")
 
@@ -12,7 +12,8 @@ def main(tf, ps, synth, row_n, col_m, ff_depth, pckt_w, regression, log_lvl) -> 
   arguments = {"ROW_N": row_n,
                "COL_M": col_m,
                "FIFO_DEPTH_W": ff_depth,
-               "PCKT_DATA_W": pckt_w}
+               "PCKT_DATA_W": pckt_w,
+               "ARB_TYPE": arb_type}
 
   if regression:
     runs = []
@@ -72,6 +73,7 @@ if __name__ == '__main__':
   parser.add_argument('-col_m', default=3, help='COL_M parameter')
   parser.add_argument('-ff_depth', default=2, help='FIFO_DEPTH_W parameter')
   parser.add_argument('-pckt_w', default=15, help='PCKT_DATA_W parameter')
+  parser.add_argument('-arb_type', default=0, help="Arbitration Type(0-matrix, 1-round robin, 2-static")
   parser.add_argument('-regression', default=0, help="IF '1' RUNS NOC simulations from 2x2 to 4x4"
                                                      " to check size problems")
   parser.add_argument('-log_lvl', default=1, help="Logging LEVEL (INFO=0, DEBUG=1)")
@@ -80,10 +82,10 @@ if __name__ == '__main__':
 
   if args.ps:
     metrics_filename = f"mesh_noc_xy_postsynth_{args.row_n}_{args.col_m}" \
-                       f"_{args.ff_depth}_{args.pckt_w}.json"
+                       f"_{args.ff_depth}_{args.pckt_w}_arb{args.arb_type}.json"
   else:
     metrics_filename = f"mesh_noc_xy_presynth_{args.row_n}_{args.col_m}" \
-                       f"_{args.ff_depth}_{args.pckt_w}.json"
+                       f"_{args.ff_depth}_{args.pckt_w}_arb{args.arb_type}.json"
 
 
   if os.path.exists(metrics_filename):

--- a/sim/functional/mesh_xy_noc/tb.sv
+++ b/sim/functional/mesh_xy_noc/tb.sv
@@ -8,7 +8,8 @@ module tb
     parameter COL_M = 3,
     parameter FIFO_DEPTH_W = 3,
     parameter PCKT_DATA_W = 8,
-    parameter CLK_PERIOD = 10
+    parameter CLK_PERIOD = 10,
+    parameter ARB_TYPE = 0
     )
   (
     // GLOBAL
@@ -34,6 +35,7 @@ module tb
       $display("COL_M %d", COL_M);
       $display("FIFO_DEPTH_W %d", FIFO_DEPTH_W);
       $display("PCKT_DATA_W %d", PCKT_DATA_W);
+      $display("ARB_TYPE %d", ARB_TYPE);
     end
 
     reg clk_i = 1'b0;
@@ -57,7 +59,8 @@ module tb
       .ROW_N(ROW_N),
       .COL_M(COL_M),
       .FIFO_DEPTH_W(FIFO_DEPTH_W),
-      .PCKT_DATA_W(PCKT_DATA_W)
+      .PCKT_DATA_W(PCKT_DATA_W),
+      .ARB_TYPE(ARB_TYPE)
       )
     inst_mesh_xy_noc
     (

--- a/sim/functional/mesh_xy_noc/test.py
+++ b/sim/functional/mesh_xy_noc/test.py
@@ -60,6 +60,7 @@ class NocTB:
             "fifo_depth_w": int(os.environ["FIFO_DEPTH_W"]),
             "col_addr_w": ceil(log(int(os.environ["COL_M"]), 2)),
             "row_addr_w": ceil(log(int(os.environ["ROW_N"]), 2)),
+            "arb_type": ceil(int(os.environ["ARB_TYPE"])),
             "clk_period": int(os.environ["CLK_PERIOD"])
         }
 

--- a/sim/functional/xy_switch/Makefile
+++ b/sim/functional/xy_switch/Makefile
@@ -15,6 +15,8 @@ VERILOG_SOURCES += $(VER_DIR)/simple_mesh_xy/switch_constants.v
 VERILOG_SOURCES += $(VER_DIR)/simple_mesh_xy/xy_switch.v
 VERILOG_SOURCES += $(VER_DIR)/simple_mesh_xy/control_unit.v
 VERILOG_SOURCES += $(VER_DIR)/arbiters/matrix_arbiter.v
+VERILOG_SOURCES += $(VER_DIR)/arbiters/round_robin.v
+VERILOG_SOURCES += $(VER_DIR)/arbiters/static_priority_arbiter.v
 VERILOG_SOURCES += $(VER_DIR)/crossbars/nxn_single_crossbar.v
 VERILOG_SOURCES += $(VER_DIR)/routers/xy_router.v
 ifeq ($(SYNTH), 1)
@@ -39,6 +41,7 @@ export PACKET_DATA_W     ?= 16
 PCKT_W_calc              =  $(shell expr $(PACKET_COL_ADDR_W) + $(PACKET_ROW_ADDR_W) + $(PACKET_DATA_W) )
 export PACKET_W          ?= $(PCKT_W_calc)
 export IN_FIFO_DEPTH_W   ?= 2
+export ARB_TYPE          ?= 0
 
 COCOTB_HDL_TIMEUNIT      = 1ns
 COCOTB_HDL_TIMEPRECISION = 1ps
@@ -51,6 +54,7 @@ COMPILE_ARGS += -P $(TOPLEVEL).PACKET_COL_ADDR_W=$(PACKET_COL_ADDR_W)
 COMPILE_ARGS += -P $(TOPLEVEL).PACKET_ROW_ADDR_W=$(PACKET_ROW_ADDR_W)
 COMPILE_ARGS += -P $(TOPLEVEL).PACKET_DATA_W=$(PACKET_DATA_W)
 COMPILE_ARGS += -P $(TOPLEVEL).IN_FIFO_DEPTH_W=$(IN_FIFO_DEPTH_W)
+COMPILE_ARGS += -P $(TOPLEVEL).ARB_TYPE=$(ARB_TYPE)
 COMPILE_ARGS += -D SIMULATION=1
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/sim/functional/xy_switch/mon_i.py
+++ b/sim/functional/xy_switch/mon_i.py
@@ -101,38 +101,39 @@ class SWIMon(BusMonitor):
                     y_addr = BinaryValue(chosen_pckt[0:self.config["packet_y_addr_w"]],
                                          self.config["packet_y_addr_w"], bigEndian=False).value
 
-                    if not in_fifo_full_cur[self.port_n-bid] or (in_fifo_full_cur[self.port_n-bid] and in_fifo_rd_en_i_cur[self.port_n-bid]):
+                    # if not in_fifo_full_cur[self.port_n-bid] or (in_fifo_full_cur[self.port_n-bid] and in_fifo_rd_en_i_cur[self.port_n-bid]):
                         # Router XY algorithm
 
-                        if x_addr == self.config["x_cord"]:
-                            if y_addr == self.config["y_cord"]:
-                                dst = self.directions["resource"]
-                            elif y_addr < self.config["y_cord"]:
-                                dst = self.directions["up"]
-                            else:
-                                dst = self.directions["down"]
-                        elif x_addr > self.config["x_cord"]:
-                            dst = self.directions["right"]
+                    if x_addr == self.config["x_cord"]:
+                        if y_addr == self.config["y_cord"]:
+                            dst = self.directions["resource"]
+                        elif y_addr < self.config["y_cord"]:
+                            dst = self.directions["up"]
                         else:
-                            dst = self.directions["left"]
-
-                        cycle_results = {"id": data, "dst": dst, "orig": chosen_pckt}
-                        self.log.debug(f"Acc {self.acc_packets.__len__()}. {cycle_results}, src: {self.port_n-bid}")
-
-                        self.acc_packets.append(cycle_results)
-                        self._recv(cycle_results)
-
+                            dst = self.directions["down"]
+                    elif x_addr > self.config["x_cord"]:
+                        dst = self.directions["right"]
                     else:
-                        cycle_results = {"id": data,
-                                         "bid": self.port_n-bid,
-                                         "full": in_fifo_full_cur[self.port_n-bid],
-                                         "fifo_id": self.input_fifos[self.port_n-bid].config["fifo_id"],
-                                         "ovrflow": in_fifo_overflow_cur[bid],
-                                         "wr_en": wr_en_sw_i.binstr}
+                        dst = self.directions["left"]
 
-                        self.log.debug(f"Loss {cycle_results}")
+                    cycle_results = {"id": data, "dst": dst, "orig": chosen_pckt}
+                    self.log.debug(f"Acc {self.acc_packets.__len__()}. {cycle_results}, src: {self.port_n-bid}")
 
-                        self.loss_packets.append(cycle_results)
+                    self.acc_packets.append(cycle_results)
+                    self._recv(cycle_results)
+
+                    # else:
+                    #     print("DROPAGE")
+                    #     cycle_results = {"id": data,
+                    #                      "bid": self.port_n-bid,
+                    #                      "full": in_fifo_full_cur[self.port_n-bid],
+                    #                      "fifo_id": self.input_fifos[self.port_n-bid].config["fifo_id"],
+                    #                      "ovrflow": in_fifo_overflow_cur[bid],
+                    #                      "wr_en": wr_en_sw_i.binstr}
+
+                    #     self.log.debug(f"Loss {cycle_results}")
+
+                    #     self.loss_packets.append(cycle_results)
 
     def reset(self):
         self.acc_packets = []

--- a/sim/functional/xy_switch/mon_o.py
+++ b/sim/functional/xy_switch/mon_o.py
@@ -57,9 +57,6 @@ class SWOMon(BusMonitor):
             await ro
             bus_values = self.bus.capture()
 
-            in_fifo_full_o = bus_values["in_fifo_full_o"].value
-            in_fifo_overflow_o = bus_values["in_fifo_overflow_o"].value
-
             wr_en_sw_o = bus_values["wr_en_sw_o"].binstr
             pckt_sw_o = bus_values["pckt_sw_o"].binstr
 

--- a/sim/functional/xy_switch/run_and_verify.py
+++ b/sim/functional/xy_switch/run_and_verify.py
@@ -5,7 +5,7 @@ from utils.logger import *
 from utils.rav import *
 
 def main(tf, ps, synth, port_n, pckt_data_w, fifo_depth_w, row_cord, col_cord,
-             row_addr_w, col_addr_w, log_lvl) -> None:
+             row_addr_w, col_addr_w, arb_type, log_lvl) -> None:
   log = get_logger(__name__, int(log_lvl))
   log.info(f"RUN {time.asctime()}")
   log.info("----------------------------------------------------------------------------------------------------"
@@ -18,7 +18,8 @@ def main(tf, ps, synth, port_n, pckt_data_w, fifo_depth_w, row_cord, col_cord,
                "COL_CORD": col_cord,
                "ROW_ADDR_W": row_addr_w,
                "COL_ADDR_W": col_addr_w,
-               "FIFO_DEPTH_W": fifo_depth_w}
+               "FIFO_DEPTH_W": fifo_depth_w,
+               "ARB_TYPE": arb_type}
 
   run = simulate(log, tf, ps, synth, arguments, tcl_script)
   if run[0]:  # FAILED RUN
@@ -50,6 +51,7 @@ if __name__ == '__main__':
   parser.add_argument('-col_cord', default=1,     help='Cow Coordinate of the NODE(def=1)')
   parser.add_argument('-row_addr_w', default=4,   help='Width of Row Address(def=2)')
   parser.add_argument('-col_addr_w', default=4,   help='Width of Col Address(def=2)')
+  parser.add_argument('-arb_type', default=0,   help='Arbitration Type (0-matrix, 1-rr, 2-static')
 
   parser.add_argument('-log_lvl', default=1, help="Logging LEVEL (INFO=0, DEBUG=1)")
 

--- a/sim/functional/xy_switch/tb.v
+++ b/sim/functional/xy_switch/tb.v
@@ -7,7 +7,8 @@ module tb
     parameter PACKET_COL_ADDR_W = 4,
     parameter PACKET_ROW_ADDR_W = 4,
     parameter PACKET_DATA_W = 8,
-    parameter PACKET_W = PCKT_COL_ADDR_W + PCKT_ROW_ADDR_W + PCKT_DATA_W
+    parameter ARB_TYPE = 0,
+    parameter PACKET_W = PACKET_COL_ADDR_W + PACKET_ROW_ADDR_W + PACKET_DATA_W
     )
   (
 
@@ -37,8 +38,7 @@ module tb
     reg clk_i = 1'b0;
     always #5 clk_i <= ~clk_i;
 
-    xy_switch
-    #(
+    xy_switch #(
       .COL_CORD(COL_CORD),
       .ROW_CORD(ROW_CORD),
       .PORT_N(PORT_N),
@@ -46,10 +46,9 @@ module tb
       .PCKT_COL_ADDR_W(PACKET_COL_ADDR_W),
       .PCKT_ROW_ADDR_W(PACKET_ROW_ADDR_W),
       .PCKT_DATA_W(PACKET_DATA_W),
-      .PCKT_W(PACKET_W)
-      )
-    xy_switch_inst
-    (
+      .PCKT_W(PACKET_W),
+      .ARB_TYPE(ARB_TYPE)
+    ) xy_switch_inst (
       .clk_i(clk_i),
       .rst_ni(rst_ni),
       .wr_en_sw_i(wr_en_sw_i),
@@ -60,7 +59,7 @@ module tb
       .nxt_fifo_overflow_i(nxt_fifo_overflow_i),
       .wr_en_sw_o(wr_en_sw_o),
       .pckt_sw_o(pckt_sw_o)
-      );
+    );
 
     // the "macro" to dump signals
     `ifdef COCOTB_SIM

--- a/sim/functional/xy_switch/test.py
+++ b/sim/functional/xy_switch/test.py
@@ -56,7 +56,7 @@ class SWTB:
         self.sw_i_mon = SWIMon(dut, "", dut.clk_i, self.config, log_lvl, callback=self.mon_i_callback)
         self.sw_o_mon = SWOMon(dut, "", dut.clk_i, self.config, log_lvl, callback=self.mon_o_callback)
 
-    def setup_dut(self, cycle_n):
+    def setup_dut(self):
         cocotb.fork(self.reset_hdl())
 
     def reset_swtb(self):
@@ -92,9 +92,6 @@ class SWTB:
             full_input.append(record)
         full_input = sorted(full_input, key=lambda k: k['id'])
         self.log.debug(f"Lenght of Full {full_input.__len__()}")
-
-        # for rid, record in enumerate(full_input):
-        #     self.log.info(f"{rid}. full {record}")
 
         sorted_seen = sorted(self.seen_out, key=lambda k: k['id'])
         self.log.info(f"Lenght of received packets {sorted_seen.__len__()}")
@@ -144,7 +141,7 @@ class SWTB:
 
 
 @cocotb.test()
-async def test_rand_single_input(dut, log_lvl=INFO, transaction_w=8, with_nxt_fifo_rand=True, cycles=100000):
+async def test_rand_single_input(dut, log_lvl=INFO, transaction_w=8):
     cocotb.log.info("----------------------------------------------------------------------------- Simulation Started!")
 
     if int(os.environ['DEBUG_ATTACH']) > 0:
@@ -152,7 +149,7 @@ async def test_rand_single_input(dut, log_lvl=INFO, transaction_w=8, with_nxt_fi
         pydevd_pycharm.settrace('localhost', port=9090, stdoutToServer=True, stderrToServer=True)
 
     swtb = SWTB(dut.xy_switch_inst, log_lvl)
-    swtb.setup_dut(cycle_n=cycles)
+    swtb.setup_dut()
 
     # Clear FIFO inputs
     swtb.reset_swtb()

--- a/srcs/noc/mesh_wormhole_xy_noc.v
+++ b/srcs/noc/mesh_wormhole_xy_noc.v
@@ -32,14 +32,16 @@ module mesh_wormhole_xy_noc#(
     parameter NODE_RADIX          = `YS_NODE_RADIX, // CONSTANT
     parameter CHANNEL_W           = `YS_CHANNEL_W,
     parameter FLIT_ID_W           = `YS_FLIT_ID_W,
-    parameter NODE_BUFFER_DEPTH_W = `YS_NODE_BUFFER_DEPTH_W
+    parameter NODE_BUFFER_DEPTH_W = `YS_NODE_BUFFER_DEPTH_W,
+    parameter ARB_TYPE            = `YS_ARB_TYPE
   `else
     parameter ROW_N               = 3,
     parameter COL_M               = 3,
     parameter NODE_RADIX          = 5, // CONSTANT
     parameter CHANNEL_W           = 8,
     parameter FLIT_ID_W           = 2, // HEAD, BODY, TAIL, NULL(not defined), CONSTANT
-    parameter NODE_BUFFER_DEPTH_W = 4
+    parameter NODE_BUFFER_DEPTH_W = 4,
+    parameter ARB_TYPE            = 0
   `endif
   ) (
     // GLOBAL
@@ -110,7 +112,8 @@ module mesh_wormhole_xy_noc#(
           .COL_ADDR_W     ($clog2(COL_M)),
           .ROW_CORD       (row_idx),
           .COL_CORD       (col_idx),
-          .BUFFER_DEPTH_W (NODE_BUFFER_DEPTH_W)
+          .BUFFER_DEPTH_W (NODE_BUFFER_DEPTH_W),
+          .ARB_TYPE       (ARB_TYPE)
           )
         x_node (
           .clk_i            (clk_i),

--- a/srcs/noc/mesh_xy_noc.v
+++ b/srcs/noc/mesh_xy_noc.v
@@ -31,12 +31,14 @@ module mesh_xy_noc
       parameter ROW_N         = `YS_ROW_N,
       parameter COL_M         = `YS_COL_M,
       parameter PCKT_DATA_W   = `YS_PCKT_DATA_W,
-      parameter FIFO_DEPTH_W  = `YS_FIFO_DEPTH_W
+      parameter FIFO_DEPTH_W  = `YS_FIFO_DEPTH_W,
+      parameter ARB_TYPE      = `YS_ARB_TYPE,
       `else
       parameter ROW_N         = 3,
       parameter COL_M         = 3,
       parameter PCKT_DATA_W   = 8,
-      parameter FIFO_DEPTH_W  = 3
+      parameter FIFO_DEPTH_W  = 3,
+      parameter ARB_TYPE      = 0
       `endif
       )
     (
@@ -130,7 +132,8 @@ module mesh_xy_noc
             .COL_ADDR_W($clog2(COL_M)),
             .ROW_ADDR_W($clog2(ROW_N)),
             .PCKT_DATA_W(PCKT_DATA_W),
-            .PCKT_W(`PACKET_W)
+            .PCKT_W(`PACKET_W),
+            .ARB_TYPE(ARB_TYPE)
             )
           x_sw
           (

--- a/srcs/switch/allocators/allocator.v
+++ b/srcs/switch/allocators/allocator.v
@@ -162,7 +162,7 @@ module allocator #(
       );
     end
     else begin
-      $error("Wrong Arbitration Type, possible options 0,1,2"); 
+      initial $error("Wrong Arbitration Type, possible options 0,1,2"); 
     end
   endgenerate
 

--- a/srcs/switch/arbiters/matrix_arbiter.v
+++ b/srcs/switch/arbiters/matrix_arbiter.v
@@ -26,7 +26,8 @@ module matrix_arb
     input                     clk_i,
     input                     rst_ni,
     input  [IN_N-1:0]         req_i,
-    output [$clog2(IN_N)-1:0] grant_o
+    output [$clog2(IN_N)-1:0] grant_o,
+    output                     grant_vld_o
   );
 
   // Last granted requested moves to the end of the que
@@ -78,5 +79,6 @@ module matrix_arb
     end
   end
   assign grant_o = grant_bcd_w;
+  assign grant_vld_o = |grant_w;
 
 endmodule // matrix

--- a/srcs/switch/arbiters/matrix_arbiter.v
+++ b/srcs/switch/arbiters/matrix_arbiter.v
@@ -72,10 +72,11 @@ module matrix_arb
   endgenerate
 
   // from ONEHOT to DECIMAL
+  integer k;
   always @(*) begin
     grant_bcd_w <= 0;
-    for (integer i = 0; i < IN_N; i = i + 1) begin
-      if (grant_w[i]) grant_bcd_w <= i;
+    for (k = 0; k < IN_N; k = k + 1) begin
+      if (grant_w[k]) grant_bcd_w <= k;
     end
   end
   assign grant_o = grant_bcd_w;

--- a/srcs/switch/arbiters/matrix_arbiter.v
+++ b/srcs/switch/arbiters/matrix_arbiter.v
@@ -32,7 +32,7 @@ module matrix_arb
   // Last granted requested moves to the end of the que
   reg   [IN_N-1:0]  p_matrix [IN_N-1:0];
   wire  [IN_N-1:0]  grant_w;
-  wire [$clog2(IN_N)-1:0] grant_bcd_w;
+  reg [$clog2(IN_N)-1:0] grant_bcd_w;
 
   // MATRIX UPDATE CIRC
   integer i,j;
@@ -71,11 +71,12 @@ module matrix_arb
   endgenerate
 
   // from ONEHOT to DECIMAL
-  assign grant_bcd_w = (grant_w[0]) ? 0 :
-                       (grant_w[1]) ? 1 :
-                       (grant_w[2]) ? 2 :
-                       (grant_w[3]) ? 3 :
-                       (grant_w[4]) ? 4 : 0;
+  always @(*) begin
+    grant_bcd_w <= 0;
+    for (integer i = 0; i < IN_N; i = i + 1) begin
+      if (grant_w[i]) grant_bcd_w <= i;
+    end
+  end
   assign grant_o = grant_bcd_w;
 
 endmodule // matrix

--- a/srcs/switch/arbiters/matrix_arbiter.v
+++ b/srcs/switch/arbiters/matrix_arbiter.v
@@ -27,7 +27,7 @@ module matrix_arb
     input                     rst_ni,
     input  [IN_N-1:0]         req_i,
     output [$clog2(IN_N)-1:0] grant_o,
-    output                     grant_vld_o
+    output                    grant_vld_o
   );
 
   // Last granted requested moves to the end of the que

--- a/srcs/switch/arbiters/round_robin.v
+++ b/srcs/switch/arbiters/round_robin.v
@@ -2,9 +2,53 @@
   Adam Drawc @2021
   Description:
   Arbiter that uses round_robin arbitration.
-  Provides STRONG Fairness
+  Provides STRONG Fairness over time
 
-  When request has been served it lands on the end of the q
+  When request has been served it lands on the end of the que
+
+  for every req, first to show up is the first one to be granted
+  after grant, agent that got it moves to the bottom of the que
+  every other agent moves up
+  what if the initial state is uknown and at the same time, 2 req come
+  then you choose the one with a smaller symbol
+
+  BIG logic implementation
+  if it's a round-robin we could do a que
+  you number each input, and then with each grant you place the number corresponding to the granted input at the bottom of the que (LEFT shift & last granted number)
+
+  Initial state, no history, que is blank
+  first contender, you fill the que, at this point, whoever is not in the que has priority
+  next contender comes, if he is not in the que, he gets priority aka grant
+  etc etc
+  que gets filled
+  now if any grant comes, we have a known priority of grants!
+  but still, let's assume, that at first que is initialized in an increasing order 
+  this already gives us a bit of knowledge and we don't need to guess /fill the priority list
+  then if 2 inputs come then we already know whch one should go first!
+
+  Eventually you get to a point that
+  in 0 and 3 want access
+  now you need to decide which input will be granted  the access
+  you have 2 things, your inputs, your table of priority
+
+  each input here gets a numerical priority
+  if 2 inputs come the one with the biggest priority should get access
+  after that we could simply update priorities of everybody (add 1, lshift)
+
+  priority depicted as the spot in the que
+  each spot knows it's input id
+  if we have our que, then every cycle we could 
+  1. see if there are requests
+  2. going from the start of the que, check which inputs are HIGH
+  3. as soon as we decide which input currently holds the highest priority
+  4. we look at his index, and we only shift up to his index, placing him at the end
+  
+  this sounds like a lot of dynamic stuff
+  1. you either add / subtract  depending on the grant
+  2. figure out who to move and do that
+
+  reg [$clog2(IN_N)-1:0] last_grant, new_grant;
+  reg [$clog2(IN_N)-1:0] p_que [IN_N-1 : 0];
 
 */
 `timescale 1ns / 1ps
@@ -15,6 +59,7 @@ module round_robin_arb
     )
   (
     input                  clk_i,
+    input                  rst_ni,
     input   [IN_N - 1 : 0] req_i,
     output  [IN_N - 1 : 0] grant_o
   );
@@ -22,12 +67,103 @@ module round_robin_arb
   // Last granted requested moves to the end of the que
   reg [IN_N -1 : 0] grant;
 
-  always (posedge clk_i) begin : grant_circ
-    grant <=
+  wire [IN_N-1 :0] new_p_table [IN_N-1 : 0];
+  reg [IN_N-1 :0] p_table [IN_N-1 : 0];
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      for (integer i = 0; i < IN_N; i=i+1 ) begin
+        p_table[i] <= 1 << i;
+      end
+    end
+    else begin
+      
+    end
   end
 
-
-
-
-
+  genvar i;
+  generate
+    wire [IN_N : 0] c_grant;
+    
+    assign c_grant[0] = 1'b0;
+    for (i = 0; i < IN_N; i = i + 1) begin
+      if (i == 0) begin
+        granter_with_shifitng_p #(
+          .REQ_N(IN_N),
+          .INITIAL_PRIORITY( 1)
+        ) x_grant (
+          .clk_i      (clk_i),
+          .rst_ni     (rst_ni),
+          .c_grant_i  (c_grant[i]),
+          .c_grant_o  (c_grant[i+1]),
+          .ext_p_val_i(p_table[i]),
+          .grant_o    (grant[i])
+          .p_val_o    (),
+        );
+      end
+      else if (i == IN_N - 1) begin
+        granter_with_shifitng_p #(
+          .REQ_N(IN_N),
+          .INITIAL_PRIORITY( 1 << i)
+        ) x_grant (
+          .clk_i      (clk_i),
+          .rst_ni     (rst_ni),
+          .c_grant_i  (c_grant[i]),
+          .c_grant_o  (c_grant[IN_N]),
+          .ext_p_val_i(p_table[i]),
+          .grant_o    (grant[i])
+          .p_val_o    (),
+        );
+      end
+      else begin
+        granter_with_shifitng_p #(
+          .REQ_N(IN_N),
+          .INITIAL_PRIORITY(IN_N)
+        ) x_grant (
+          .clk_i      (clk_i),
+          .rst_ni     (rst_ni),
+          .c_grant_i  (c_grant[i]),
+          .c_grant_o  (c_grant[i+1]),
+          .ext_p_val_i(p_table[i]),
+          .grant_o    (grant[i])
+          .p_val_o    (new_p_table[i+1]),
+        );
+      end
+    end
+  endgenerate
 endmodule // round_robin_arb
+
+module granter_with_shifitng_p  #(
+  parameter REQ_N = 5,
+  parameter INITIAL_PRIORITY = 5'b00001 // has to be onehot
+) (
+  input               rst_ni,
+  input               clk_i,
+  input  [REQ_N-1: 0] req_i,
+  input               c_grant_i,
+  output              c_grant_o,
+  input  [REQ_N-1 :0] ext_p_val_i,
+  output [REQ_N-1:0]  p_val_o,
+  output              grant_o
+);
+
+  reg [REQ_N-1:0] cur_p_val;
+  reg [REQ_N-1:0] p_val;
+  assign c_grant_o = c_grant_i | grant_o;
+  assign grant_o   = (c_grant_i == 1'b0) ? |(req_i && cur_p_val): 1'b0; 
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (rst_ni == 1'b0) begin
+      cur_p_val <= INITIAL_PRIORITY; 
+      p_val     <= INITIAL_PRIORITY;
+    end
+    else begin
+      if (c_grant_o == 1'b1) begin
+        cur_p_val <= ext_p_val_i;
+        p_val   <= cur_p_val;
+      end
+    end
+  end
+
+  assign p_val_o = p_val;
+
+endmodule

--- a/srcs/switch/arbiters/round_robin.v
+++ b/srcs/switch/arbiters/round_robin.v
@@ -1,54 +1,11 @@
 /*
   Adam Drawc @2021
   Description:
-  Arbiter that uses round_robin arbitration.
-  Provides STRONG Fairness over time
-
-  When request has been served it lands on the end of the que
-
-  for every req, first to show up is the first one to be granted
-  after grant, agent that got it moves to the bottom of the que
-  every other agent moves up
-  what if the initial state is uknown and at the same time, 2 req come
-  then you choose the one with a smaller symbol
-
-  BIG logic implementation
-  if it's a round-robin we could do a que
-  you number each input, and then with each grant you place the number corresponding to the granted input at the bottom of the que (LEFT shift & last granted number)
-
-  Initial state, no history, que is blank
-  first contender, you fill the que, at this point, whoever is not in the que has priority
-  next contender comes, if he is not in the que, he gets priority aka grant
-  etc etc
-  que gets filled
-  now if any grant comes, we have a known priority of grants!
-  but still, let's assume, that at first que is initialized in an increasing order 
-  this already gives us a bit of knowledge and we don't need to guess /fill the priority list
-  then if 2 inputs come then we already know whch one should go first!
-
-  Eventually you get to a point that
-  in 0 and 3 want access
-  now you need to decide which input will be granted  the access
-  you have 2 things, your inputs, your table of priority
-
-  each input here gets a numerical priority
-  if 2 inputs come the one with the biggest priority should get access
-  after that we could simply update priorities of everybody (add 1, lshift)
-
-  priority depicted as the spot in the que
-  each spot knows it's input id
-  if we have our que, then every cycle we could 
-  1. see if there are requests
-  2. going from the start of the que, check which inputs are HIGH
-  3. as soon as we decide which input currently holds the highest priority
-  4. we look at his index, and we only shift up to his index, placing him at the end
+  Arbiter that uses priority_robin arbitration.
   
-  this sounds like a lot of dynamic stuff
-  1. you either add / subtract  depending on the grant
-  2. figure out who to move and do that
-
-  reg [$clog2(IN_N)-1:0] last_grant, new_grant;
-  reg [$clog2(IN_N)-1:0] p_que [IN_N-1 : 0];
+  Every cycle priority shift by 1
+  If priority is high but req for that input is LOW, we lose a cycle
+  Even though there are other requests HIGH.
 
 */
 `timescale 1ns / 1ps
@@ -56,114 +13,34 @@
 module round_robin_arb
   #(
     parameter IN_N = 5 // this should be 5 right now
-    )
-  (
-    input                  clk_i,
-    input                  rst_ni,
-    input   [IN_N - 1 : 0] req_i,
-    output  [IN_N - 1 : 0] grant_o
+  ) (
+    input                      clk_i,
+    input                      rst_ni,
+    input   [IN_N-1 : 0]       req_i,  // N hot encoding
+    output  [$clog2(IN_N)-1:0] grant_o // BCD encoding
   );
 
-  // Last granted requested moves to the end of the que
-  reg [IN_N -1 : 0] grant;
+  reg [IN_N-1 : 0] priority_robin;
+  wire [IN_N-1 : 0] grant_w = priority_robin & req_i;
 
-  wire [IN_N-1 :0] new_p_table [IN_N-1 : 0];
-  reg [IN_N-1 :0] p_table [IN_N-1 : 0];
+  reg [$clog2(IN_N)-1:0] grant_bcd_w;
+  always @(*) begin
+    grant_bcd_w <= 0;
+    for (integer i = 0; i < IN_N; i = i + 1) begin
+      if (grant_w[i]) grant_bcd_w <= i;
+    end
+  end
+
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      for (integer i = 0; i < IN_N; i=i+1 ) begin
-        p_table[i] <= 1 << i;
-      end
+      priority_robin <= 1;
     end
     else begin
-      
+      priority_robin[0] <= priority_robin[IN_N-1];
+      priority_robin[IN_N-1 : 1] <= priority_robin[IN_N-2 : 0];
     end
   end
 
-  genvar i;
-  generate
-    wire [IN_N : 0] c_grant;
-    
-    assign c_grant[0] = 1'b0;
-    for (i = 0; i < IN_N; i = i + 1) begin
-      if (i == 0) begin
-        granter_with_shifitng_p #(
-          .REQ_N(IN_N),
-          .INITIAL_PRIORITY( 1)
-        ) x_grant (
-          .clk_i      (clk_i),
-          .rst_ni     (rst_ni),
-          .c_grant_i  (c_grant[i]),
-          .c_grant_o  (c_grant[i+1]),
-          .ext_p_val_i(p_table[i]),
-          .grant_o    (grant[i])
-          .p_val_o    (),
-        );
-      end
-      else if (i == IN_N - 1) begin
-        granter_with_shifitng_p #(
-          .REQ_N(IN_N),
-          .INITIAL_PRIORITY( 1 << i)
-        ) x_grant (
-          .clk_i      (clk_i),
-          .rst_ni     (rst_ni),
-          .c_grant_i  (c_grant[i]),
-          .c_grant_o  (c_grant[IN_N]),
-          .ext_p_val_i(p_table[i]),
-          .grant_o    (grant[i])
-          .p_val_o    (),
-        );
-      end
-      else begin
-        granter_with_shifitng_p #(
-          .REQ_N(IN_N),
-          .INITIAL_PRIORITY(IN_N)
-        ) x_grant (
-          .clk_i      (clk_i),
-          .rst_ni     (rst_ni),
-          .c_grant_i  (c_grant[i]),
-          .c_grant_o  (c_grant[i+1]),
-          .ext_p_val_i(p_table[i]),
-          .grant_o    (grant[i])
-          .p_val_o    (new_p_table[i+1]),
-        );
-      end
-    end
-  endgenerate
-endmodule // round_robin_arb
-
-module granter_with_shifitng_p  #(
-  parameter REQ_N = 5,
-  parameter INITIAL_PRIORITY = 5'b00001 // has to be onehot
-) (
-  input               rst_ni,
-  input               clk_i,
-  input  [REQ_N-1: 0] req_i,
-  input               c_grant_i,
-  output              c_grant_o,
-  input  [REQ_N-1 :0] ext_p_val_i,
-  output [REQ_N-1:0]  p_val_o,
-  output              grant_o
-);
-
-  reg [REQ_N-1:0] cur_p_val;
-  reg [REQ_N-1:0] p_val;
-  assign c_grant_o = c_grant_i | grant_o;
-  assign grant_o   = (c_grant_i == 1'b0) ? |(req_i && cur_p_val): 1'b0; 
-
-  always @(posedge clk_i or negedge rst_ni) begin
-    if (rst_ni == 1'b0) begin
-      cur_p_val <= INITIAL_PRIORITY; 
-      p_val     <= INITIAL_PRIORITY;
-    end
-    else begin
-      if (c_grant_o == 1'b1) begin
-        cur_p_val <= ext_p_val_i;
-        p_val   <= cur_p_val;
-      end
-    end
-  end
-
-  assign p_val_o = p_val;
+  assign grant_o = grant_bcd_w;
 
 endmodule

--- a/srcs/switch/arbiters/round_robin.v
+++ b/srcs/switch/arbiters/round_robin.v
@@ -17,7 +17,8 @@ module round_robin_arb
     input                      clk_i,
     input                      rst_ni,
     input   [IN_N-1 : 0]       req_i,  // N hot encoding
-    output  [$clog2(IN_N)-1:0] grant_o // BCD encoding
+    output  [$clog2(IN_N)-1:0] grant_o,
+    output                     grant_vld_o
   );
 
   reg [IN_N-1 : 0] priority_robin;
@@ -42,5 +43,6 @@ module round_robin_arb
   end
 
   assign grant_o = grant_bcd_w;
+  assign grant_vld_o = |grant_w;
 
 endmodule

--- a/srcs/switch/arbiters/static_priority_arbiter.v
+++ b/srcs/switch/arbiters/static_priority_arbiter.v
@@ -9,7 +9,7 @@
 `timescale 1ns / 1ps
 module static_priority_arbiter
   #(
-    parameter IN_N = 5 // this should be 5 right now
+    parameter IN_N = 5
   ) (
     input   [IN_N - 1 : 0]     req_i,
     output  [$clog2(IN_N)-1:0] grant_o

--- a/srcs/switch/arbiters/static_priority_arbiter.v
+++ b/srcs/switch/arbiters/static_priority_arbiter.v
@@ -5,6 +5,8 @@
   This in turn allows to choose which input has priority in the case when inputs
   are competing for the same channel and other arbitration doesn't provide a
   clear result.
+  req_i LSB is at the lowest priority.
+  req_i MSB is at the highest priority.
 */
 `timescale 1ns / 1ps
 module static_priority_arbiter
@@ -31,10 +33,10 @@ module static_priority_arbiter
   generate
     for ( gi = 0; gi < IN_N; gi = gi + 1) begin
       grant_with_carry x_grant (
-        .req_i   (req_i[gi]),
+        .req_i   (req_i[IN_N-1-gi]),
         .carry_i (x_carry_w[gi]),
         .carry_o (x_carry_w[gi+1]),
-        .grant_o (grant_w[gi])
+        .grant_o (grant_w[IN_N-1-gi])
       );
     end
   endgenerate 

--- a/srcs/switch/arbiters/static_priority_arbiter.v
+++ b/srcs/switch/arbiters/static_priority_arbiter.v
@@ -8,22 +8,49 @@
 */
 `timescale 1ns / 1ps
 module static_priority_arbiter
-# (
+  #(
     parameter IN_N = 5 // this should be 5 right now
-    )
-  (
-    input   [IN_N - 1 : 0]     vld_input_i,
-    output  [$clog2(IN_N)-1:0] arb_res_o
-    );
-    reg [$clog2(IN_N)-1:0] arb_res_v;
-    always @(*)
-    begin
-      if      (vld_input_i[4])  arb_res_v = 4;
-      else if (vld_input_i[3])  arb_res_v = 3;
-      else if (vld_input_i[2])  arb_res_v = 2;
-      else if (vld_input_i[1])  arb_res_v = 1;
-      else if (vld_input_i[0])  arb_res_v = 0;
-      else                      arb_res_v = 0;
+  ) (
+    input   [IN_N - 1 : 0]     req_i,
+    output  [$clog2(IN_N)-1:0] grant_o
+  );
+
+  wire [IN_N-1 : 0]      grant_w;
+  reg [$clog2(IN_N)-1:0] grant_bcd_w;
+  always @(*) begin
+    grant_bcd_w <= 0;
+    for (integer i = 0; i < IN_N; i = i + 1) begin
+      if (grant_w[i]) grant_bcd_w <= i;
     end
-    assign arb_res_o = arb_res_v;
+  end
+
+  wire [IN_N : 0] x_carry_w;
+  assign x_carry_w[0] = 0; 
+  genvar gi;
+  generate
+    for ( gi = 0; gi < IN_N-1; gi = gi + 1) begin
+      grant_with_carry x_grant (
+        .req_i   (req_i[gi]),
+        .carry_i (x_carry_w[gi]),
+        .carry_o (x_carry_w[gi+1]),
+        .grant_o (grant_w[gi])
+      );
+    end
+  endgenerate 
+
+  assign grant_o = grant_bcd_w;
+
+endmodule
+
+module grant_with_carry
+(
+  input req_i,
+  input carry_i,
+  output carry_o,
+  output grant_o
+);
+
+  assign grant_o = ~carry_i & req_i;
+  assign carry_o = carry_i | req_i;
+
 endmodule

--- a/srcs/switch/arbiters/static_priority_arbiter.v
+++ b/srcs/switch/arbiters/static_priority_arbiter.v
@@ -12,7 +12,8 @@ module static_priority_arbiter
     parameter IN_N = 5
   ) (
     input   [IN_N - 1 : 0]     req_i,
-    output  [$clog2(IN_N)-1:0] grant_o
+    output  [$clog2(IN_N)-1:0] grant_o,
+    output                     grant_vld_o
   );
 
   wire [IN_N-1 : 0]      grant_w;
@@ -28,7 +29,7 @@ module static_priority_arbiter
   assign x_carry_w[0] = 0; 
   genvar gi;
   generate
-    for ( gi = 0; gi < IN_N-1; gi = gi + 1) begin
+    for ( gi = 0; gi < IN_N; gi = gi + 1) begin
       grant_with_carry x_grant (
         .req_i   (req_i[gi]),
         .carry_i (x_carry_w[gi]),
@@ -38,7 +39,8 @@ module static_priority_arbiter
     end
   endgenerate 
 
-  assign grant_o = grant_bcd_w;
+  assign grant_o     = grant_bcd_w;
+  assign grant_vld_o = |grant_w;
 
 endmodule
 

--- a/srcs/switch/mesh_wormhole/mesh_wormhole_node.v
+++ b/srcs/switch/mesh_wormhole/mesh_wormhole_node.v
@@ -25,7 +25,8 @@ module mesh_wormhole_node #(
     parameter COL_ADDR_W      = `YS_COL_ADDR_W,
     parameter ROW_CORD        = `YS_ROW_CORD,
     parameter COL_CORD        = `YS_COL_CORD,
-    parameter BUFFER_DEPTH_W  = `YS_BUFFER_DEPTH_W
+    parameter BUFFER_DEPTH_W  = `YS_BUFFER_DEPTH_W,
+    parameter ARB_TYPE        = `YS_ARB_TYPE
   `else
     parameter IN_N            = 5,
     parameter OUT_M           = 5,
@@ -35,7 +36,8 @@ module mesh_wormhole_node #(
     parameter COL_ADDR_W      = 2,
     parameter ROW_CORD        = 1,
     parameter COL_CORD        = 1,
-    parameter BUFFER_DEPTH_W  = 2
+    parameter BUFFER_DEPTH_W  = 2,
+    parameter ARB_TYPE        = 0
   `endif
   ) (
     input clk_i,
@@ -120,7 +122,8 @@ module mesh_wormhole_node #(
         .IN_N(IN_N),
         .OUT_M(OUT_M),
         .FLIT_ID_W(FLIT_ID_W),
-        .OUT_CHAN_ID(gi)
+        .OUT_CHAN_ID(gi),
+        .ARB_TYPE(ARB_TYPE)
         )
       x_alloc (
         .clk_i(clk_i),

--- a/srcs/switch/simple_mesh_xy/control_unit.v
+++ b/srcs/switch/simple_mesh_xy/control_unit.v
@@ -22,15 +22,15 @@ module control_unit
 
     // Router Input
     input [$clog2(PORT_N)-1 : 0] mux_in_sel_i,
+    input                        mux_in_sel_vld_i,
     input [$clog2(PORT_N)-1 : 0] mux_out_sel_i
-
     );
 
     reg   [PORT_N-1 : 0]    vld_input_v;
     integer i;
 
     wire  [PORT_N-1 : 0]    rd_en_w = ~( empty_i | vld_input_v );
-    wire  [PORT_N - 1 : 0]  wr_en_w = (|vld_input_v) ? (1 << mux_out_sel_i) & (~full_i) : 0;
+    wire  [PORT_N - 1 : 0]  wr_en_w = (|vld_input_v & mux_in_sel_vld_i) ? (1 << mux_out_sel_i) & (~full_i) : 0;
 
     // Read while HOT
     // rd_en control

--- a/srcs/switch/simple_mesh_xy/xy_switch.v
+++ b/srcs/switch/simple_mesh_xy/xy_switch.v
@@ -81,6 +81,7 @@ module xy_switch
     // Wires
     wire [PORT_N -1 : 0]            vld_input_w;
     wire [$clog2(PORT_N) - 1 : 0]   mux_in_sel_w;
+    wire                            mux_in_sel_vld_w;
     wire [$clog2(PORT_N) - 1 : 0]   mux_out_sel_w;
     wire [PCKT_W * PORT_N - 1 : 0]  data_out_w;
     wire [PCKT_W - 1 : 0]           pckt_in_chosen_w;
@@ -134,32 +135,35 @@ module xy_switch
         matrix_arb #(
           .IN_N(PORT_N)
         ) arb (
-          .clk_i    (clk_i),
-          .rst_ni   (rst_ni),
-          .req_i    (vld_input_w),
-          .grant_o  (mux_in_sel_w)
+          .clk_i      (clk_i),
+          .rst_ni     (rst_ni),
+          .req_i      (vld_input_w),
+          .grant_o    (mux_in_sel_w),
+          .grant_vld_o(mux_in_sel_vld_w)
         );
       end
       else if (ARB_TYPE == 1) begin
         round_robin_arb #(
           .IN_N(PORT_N)
         ) arb (
-          .clk_i    (clk_i),
-          .rst_ni   (rst_ni),
-          .req_i    (vld_input_w ),
-          .grant_o  (mux_in_sel_w)
+          .clk_i      (clk_i),
+          .rst_ni     (rst_ni),
+          .req_i      (vld_input_w ),
+          .grant_o    (mux_in_sel_w),
+          .grant_vld_o(mux_in_sel_vld_w)
         );
       end
       else if (ARB_TYPE == 2) begin
         static_priority_arbiter #(
           .IN_N(PORT_N)
         ) arb (
-          .req_i    (vld_input_w ),
-          .grant_o  (mux_in_sel_w)
+          .req_i      (vld_input_w ),
+          .grant_o    (mux_in_sel_w),
+          .grant_vld_o(mux_in_sel_vld_w)
         );
       end
       else begin
-        $error("Wrong Arbitration Type, possible options 0,1,2"); 
+        initial $error("Wrong Arbitration Type, possible options 0,1,2");   
       end
     endgenerate
 
@@ -191,6 +195,7 @@ module xy_switch
         .full_i(nxt_fifo_full_i), // do we have FIFOs that will be full? IF yes this channel is blocked and we cant route the data to it
         .empty_i(empty_w), // look at the input FIFOs and check if any has data to be routed
         .mux_in_sel_i(mux_in_sel_w), // if there is data, pass the correct MUXINSEL value to the input MUX of the crossbar
+        .mux_in_sel_vld_i(mux_in_sel_vld_w),
         .mux_out_sel_i(mux_out_sel_w),
         .rd_en_o(rd_en_w),
         .wr_en_o(wr_en_sw_o),

--- a/synth/allocator.tcl
+++ b/synth/allocator.tcl
@@ -2,7 +2,9 @@ yosys -import
 set std_lib $::env(STD_LIB)
 
 read_verilog -defer ../srcs/switch/constants.v
-read_verilog -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog -sv -defer ../srcs/switch/arbiters/round_robin.v
+read_verilog -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
 
 set top_module allocator
 # Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
@@ -10,12 +12,16 @@ set params(0) IN_N
 set params(1) OUT_M
 set params(2) FLIT_ID_W
 set params(3) OUT_CHAN_ID
+set params(4) ARB_TYPE
 
 #default values for synth
 set values(0) 5
 set values(1) 5
 set values(2) 2
 set values(3) 1
+# ARB TYPE 
+# 0 - matrix, 1 round robin 2 static
+set values(4) 1
 
 chparam -list
 log "Parameters and their values:"
@@ -35,11 +41,12 @@ if {$::env(SHOW_PARAMS) == 1} {
   exit 0
 }
 
-read_verilog  -DYS_ALLOCATOR_TOP=1 \
+read_verilog -sv -DYS_ALLOCATOR_TOP=1 \
               -DYS_$params(0)=$values(0) \
               -DYS_$params(1)=$values(1) \
               -DYS_$params(2)=$values(2) \
               -DYS_$params(3)=$values(3) \
+              -DYS_$params(4)=$values(4) \
               ../srcs/switch/allocators/allocator.v
 
 echo off

--- a/synth/cmos_cells.tcl
+++ b/synth/cmos_cells.tcl
@@ -1,6 +1,6 @@
 yosys -import
-set std_lib std_libs/osu18_std.lib
-#read_liberty ~/opt/yosys/examples/cmos/cmos_cells.lib
+set std_lib $::env(STD_LIB)
+
 read_liberty $std_lib
 
 write_verilog ./cmos_cells.v

--- a/synth/hop_cnt_arb.tcl
+++ b/synth/hop_cnt_arb.tcl
@@ -24,13 +24,13 @@ for { set index 0 }  { $index < [array size params] }  { incr index } {
 # IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
 # it also shows params and values lists of parameters that are modifiable and their default values
 if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/arbiters/hop_cnt_arbiter.v
+  read_verilog -sv ../srcs/switch/arbiters/hop_cnt_arbiter.v
   log "Parameters from the top-module"
   chparam -list
   exit 0
 }
 
-read_verilog  -DYS_HOP_CNT_ARB_TOP=1 \
+read_verilog -sv -DYS_HOP_CNT_ARB_TOP=1 \
               -DYS_$params(0)=$values(0) \
               -DYS_$params(1)=$values(1) \
               ../srcs/switch/arbiters/hop_cnt_arbiter.v

--- a/synth/matrix_arb.tcl
+++ b/synth/matrix_arb.tcl
@@ -1,7 +1,7 @@
 yosys -import
 set std_lib $::env(STD_LIB)
 
-read_verilog -defer ../srcs/switch/constants.v
+read_verilog -sv -defer ../srcs/switch/constants.v
 
 set top_module matrix_arb
 # Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
@@ -22,13 +22,13 @@ for { set index 0 }  { $index < [array size params] }  { incr index } {
 # IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
 # it also shows params and values lists of parameters that are modifiable and their default values
 if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/arbiters/matrix_arbiter.v
+  read_verilog -sv ../srcs/switch/arbiters/matrix_arbiter.v
   log "Parameters from the top-module"
   chparam -list
   exit 0
 }
 
-read_verilog ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog -sv ../srcs/switch/arbiters/matrix_arbiter.v
 
 echo off
 hierarchy -top $top_module -keep_portwidths -check

--- a/synth/mesh_wh_xy_noc.tcl
+++ b/synth/mesh_wh_xy_noc.tcl
@@ -4,7 +4,9 @@ set std_lib $::env(STD_LIB)
 read_verilog  -defer ../srcs/components/circ_fifo.v
 read_verilog  -defer ../srcs/switch/constants.v
 read_verilog  -defer ../srcs/switch/virtual_channels/virtual_channel.v
-read_verilog  -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog -sv -defer ../srcs/switch/arbiters/round_robin.v
+read_verilog -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
 read_verilog  -defer ../srcs/switch/routers/xy_router.v
 read_verilog  -defer ../srcs/switch/crossbars/nxn_parrallel_crossbar.v
 read_verilog  -defer ../srcs/switch/allocators/allocator.v
@@ -20,6 +22,7 @@ set params(2) NODE_RADIX
 set params(3) CHANNEL_W
 set params(4) FLIT_ID_W
 set params(5) NODE_BUFFER_DEPTH_W
+set params(6) ARB_TYPE
 
 set values(0) 3
 set values(1) 3
@@ -27,6 +30,7 @@ set values(2) 5
 set values(3) 10
 set values(4) 2
 set values(5) 2
+set values(6) 0
 
 chparam -list
 log "Parameters and their values:(after they were overriden with arguments)"
@@ -56,6 +60,7 @@ read_verilog  -DYS_MESH_WH_XY_TOP=1 \
               -DYS_$params(3)=$values(3) \
               -DYS_$params(4)=$values(4) \
               -DYS_$params(5)=$values(5) \
+              -DYS_$params(6)=$values(6) \
               ../srcs/noc/mesh_wormhole_xy_noc.v
 
 echo off

--- a/synth/mesh_wormhole_node.tcl
+++ b/synth/mesh_wormhole_node.tcl
@@ -4,7 +4,9 @@ set std_lib $::env(STD_LIB)
 read_verilog  -defer ../srcs/components/circ_fifo.v
 read_verilog  -defer ../srcs/switch/constants.v
 read_verilog  -defer ../srcs/switch/virtual_channels/virtual_channel.v
-read_verilog  -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog  -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog  -sv -defer ../srcs/switch/arbiters/round_robin.v
+read_verilog  -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
 read_verilog  -defer ../srcs/switch/arbiters/hop_cnt_arbiter.v
 read_verilog  -defer ../srcs/switch/routers/xy_router.v
 read_verilog  -defer ../srcs/switch/crossbars/nxn_parrallel_crossbar.v
@@ -23,6 +25,7 @@ set params(5) ROW_ADDR_W
 set params(6) FLIT_ID_W
 set params(7) FLIT_DATA_W
 set params(8) BUFFER_DEPTH_W
+set params(9) ARB_TYPE
 
 set values(0) 1
 set values(1) 1
@@ -33,6 +36,7 @@ set values(5) 2
 set values(6) 2
 set values(7) 8
 set values(8) 2
+set values(9) 0
 
 chparam -list
 log "Parameters and their values:(after they were overriden with arguments)"
@@ -54,7 +58,7 @@ if {$::env(SHOW_PARAMS) == 1} {
 
 echo on
 
-read_verilog  -DYS_MESH_WORMHOLE_NODE_TOP=1 \
+read_verilog -sv -DYS_MESH_WORMHOLE_NODE_TOP=1 \
               -DYS_$params(0)=$values(0) \
               -DYS_$params(1)=$values(1) \
               -DYS_$params(2)=$values(2) \
@@ -64,6 +68,7 @@ read_verilog  -DYS_MESH_WORMHOLE_NODE_TOP=1 \
               -DYS_$params(6)=$values(6) \
               -DYS_$params(7)=$values(7) \
               -DYS_$params(8)=$values(8) \
+              -DYS_$params(9)=$values(9) \
               ../srcs/switch/mesh_wormhole/mesh_wormhole_node.v
 
 echo off

--- a/synth/mesh_xy_noc.tcl
+++ b/synth/mesh_xy_noc.tcl
@@ -4,8 +4,9 @@ set std_lib $::env(STD_LIB)
 read_verilog -defer ../srcs/switch/constants.v
 read_verilog -defer ../srcs/components/circ_fifo.v
 read_verilog -defer ../srcs/switch/simple_mesh_xy/switch_constants.v
-read_verilog -defer ../srcs/switch/arbiters/static_priority_arbiter.v
-read_verilog -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
+read_verilog -sv -defer ../srcs/switch/arbiters/round_robin.v
+read_verilog -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
 read_verilog -defer ../srcs/switch/routers/xy_router.v
 read_verilog -defer ../srcs/switch/crossbars/nxn_single_crossbar.v
 read_verilog -defer ../srcs/switch/simple_mesh_xy/control_unit.v
@@ -19,12 +20,14 @@ set params(0) ROW_N
 set params(1) COL_M
 set params(2) PCKT_DATA_W
 set params(3) FIFO_DEPTH_W
+set params(4) ARB_TYPE
 
 #default values for synth
 set values(0) 4
 set values(1) 4
 set values(2) 8
 set values(3) 4
+set values(4) 0
 
 chparam -list
 log "Parameters and their values:(after they were overriden with arguments)"
@@ -52,6 +55,7 @@ read_verilog  -DYS_MESH_XY_TOP=1 \
               -DYS_$params(1)=$values(1) \
               -DYS_$params(2)=$values(2) \
               -DYS_$params(3)=$values(3) \
+              -DYS_$params(4)=$values(4) \
               ../srcs/noc/mesh_xy_noc.v
 echo off
 hierarchy -top $top_module -keep_portwidths -check

--- a/synth/static_arb.tcl
+++ b/synth/static_arb.tcl
@@ -22,13 +22,13 @@ for { set index 0 }  { $index < [array size params] }  { incr index } {
 # IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
 # it also shows params and values lists of parameters that are modifiable and their default values
 if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/arbiters/static_priority_arbiter.v
+  read_verilog -sv ../srcs/switch/arbiters/static_priority_arbiter.v
   log "Parameters from the top-module"
   chparam -list
   exit 0
 }
 
-read_verilog  -DYS_STATIC_PRIORITY_ARBITER_TOP=1 \
+read_verilog -sv -DYS_STATIC_PRIORITY_ARBITER_TOP=1 \
               -DYS_$params(0)=$values(0) \
               ../srcs/switch/arbiters/static_priority_arbiter.v
 

--- a/synth/sw_xy_synth.tcl
+++ b/synth/sw_xy_synth.tcl
@@ -4,8 +4,9 @@ set std_lib $::env(STD_LIB)
 read_verilog  -defer ../srcs/switch/constants.v
 read_verilog  -defer ../srcs/components/circ_fifo.v
 read_verilog  -defer ../srcs/switch/simple_mesh_xy/switch_constants.v
-read_verilog  -defer ../srcs/switch/arbiters/static_priority_arbiter.v
-read_verilog  -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog  -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
+read_verilog  -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
+read_verilog  -sv -defer ../srcs/switch/arbiters/round_robin.v
 read_verilog  -defer ../srcs/switch/routers/xy_router.v
 read_verilog  -defer ../srcs/switch/crossbars/nxn_single_crossbar.v
 read_verilog  -defer ../srcs/switch/simple_mesh_xy/control_unit.v
@@ -21,6 +22,7 @@ set params(3) FIFO_DEPTH_W
 set params(4) COL_ADDR_W
 set params(5) ROW_ADDR_W
 set params(6) PCKT_DATA_W
+set params(7) ARB_TYPE
 
 set values(0) 1
 set values(1) 1
@@ -33,6 +35,8 @@ set values(4) 2
 set values(5) 2
 
 set values(6) 64
+
+set values(7) 0
 
 chparam -list
 log "Parameters and their values:(after they were overriden with arguments)"
@@ -62,6 +66,7 @@ read_verilog  -DYS_XY_SW_TOP=1 \
               -DYS_$params(4)=$values(4) \
               -DYS_$params(5)=$values(5) \
               -DYS_$params(6)=$values(6) \
+              -DYS_$params(7)=$values(7) \
               ../srcs/switch/simple_mesh_xy/xy_switch.v
 
 echo off


### PR DESCRIPTION
Simple & bad implementation of round robin arbitration module

Additionally:
- made arbitration type a parameter
- redesigned static priority & matrix arbitration to support parameterization (different values of IN_N)
- temporarily disabled packet dropping functionality in mesh xy switch tb
- all arbitration modules got `grant_vld_o` signal which indicates when resource was granted (previously not possible to notice because output of the arbiter was endcoded as a decimal number from 0 to IN_N -1)
- added `-sv` switches to yosys's `read_verilog` for arbiter modules


TODO:
- test synth
- test postsynth simulation
- test formal verification
- add a simple CI test for different arbitration types

Mentions #11