### PR TITLE
Yosys wrapper update

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -154,59 +154,59 @@ jobs:
       - name: circ_fifo
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf fifo_synth.tcl --no-xdot
+          ./yosys_wrapper.sh -sf fifo_synth.tcl
 
       - name: nxn_single_crossbar
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf nxn_single_crossbar.tcl --no-xdot
+          ./yosys_wrapper.sh -sf nxn_single_crossbar.tcl
 
       - name: nxn parrallel crossbar
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf nxn_parrallel_crossbar.tcl --no-xdot
+          ./yosys_wrapper.sh -sf nxn_parrallel_crossbar.tcl
 
       - name: allocator
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf allocator.tcl --no-xdot
+          ./yosys_wrapper.sh -sf allocator.tcl
 
       - name: hop_cnt_arbiter
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf hop_cnt_arb.tcl --no-xdot
+          ./yosys_wrapper.sh -sf hop_cnt_arb.tcl
 
       - name: static_priority_arbiter
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf static_arb.tcl --no-xdot
+          ./yosys_wrapper.sh -sf static_arb.tcl
 
       - name: router
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf router_synth.tcl --no-xdot
+          ./yosys_wrapper.sh -sf router_synth.tcl
 
       - name: vc
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf virtual_channel.tcl --no-xdot
+          ./yosys_wrapper.sh -sf virtual_channel.tcl
 
       - name: wormhole xy node
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf mesh_wormhole_node.tcl --no-xdot
+          ./yosys_wrapper.sh -sf mesh_wormhole_node.tcl
 
       - name: sw_xy
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf sw_xy_synth.tcl --no-xdot
+          ./yosys_wrapper.sh -sf sw_xy_synth.tcl
 
       - name: mesh_xy noc
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf mesh_xy_noc.tcl --no-xdot
+          ./yosys_wrapper.sh -sf mesh_xy_noc.tcl
 
       - name: wormhole xy noc
         run: |
           cd synth
-          ./yosys_wrapper.sh -sf mesh_wh_xy_noc.tcl --no-xdot
+          ./yosys_wrapper.sh -sf mesh_wh_xy_noc.tcl

--- a/sim/functional/allocator/Makefile
+++ b/sim/functional/allocator/Makefile
@@ -1,22 +1,17 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-SRC_DIR=$(shell git rev-parse --show-toplevel)/srcs
+include ../common.mk
 
 # files
-VERILOG_SOURCES = $(SRC_DIR)/switch/constants.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/matrix_arbiter.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/allocators/allocator.v
+VERILOG_SOURCES = $(SRCS_DIR)/switch/constants.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/arbiters/matrix_arbiter.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/allocators/allocator.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(SRC_DIR)/switch/allocators/allocator_synth.v
+  VERILOG_SOURCES = $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/allocator-netlist.v
 endif
 VERILOG_SOURCES += ./tb.v
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL := tb
 MODULE   := test
-SIM      ?= icarus
 
 # Depending on the Simulator we want to choose different sets of arguments to pass
 export IN_N        = 5

--- a/sim/functional/circ_fifo/Makefile
+++ b/sim/functional/circ_fifo/Makefile
@@ -1,9 +1,9 @@
 include ../common.mk
 
 # files
-VERILOG_SOURCES=$(SRCS_DIR)/componentscirc_fifo.v
+VERILOG_SOURCES=$(SRCS_DIR)/components/circ_fifo.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES = $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/circ_fifo-netlist.v
 endif
 

--- a/sim/functional/circ_fifo/Makefile
+++ b/sim/functional/circ_fifo/Makefile
@@ -1,20 +1,15 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-VER_DIR=$(shell git rev-parse --show-toplevel)/srcs/components
+include ../common.mk
 
 # files
-VERILOG_SOURCES=$(VER_DIR)/circ_fifo.v
+VERILOG_SOURCES=$(SRCS_DIR)/componentscirc_fifo.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(VER_DIR)/circ_fifo_synth.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/circ_fifo-netlist.v
 endif
 
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL := circ_fifo
 MODULE   := test
-SIM      ?= icarus
 
 # Depending on the Simulator we want to choose different sets of arguments to pass
 export FIFO_DEPTH_W ?= 4

--- a/sim/functional/common.mk
+++ b/sim/functional/common.mk
@@ -1,0 +1,13 @@
+# common VARS and EXPORTS
+## EXPORTS
+export PYTHON_BIN=/usr/bin/python3
+export SHELL=/bin/bash
+export TOPLEVEL_LANG ?= verilog
+## VARS
+GIT_ROOT=$(shell git rev-parse --show-toplevel)
+SRCS_DIR=$(GIT_ROOT)/srcs
+SYNTH_DIR=$(GIT_ROOT)/synth
+CMOS_CELLS=$(SYNTH_DIR)/cmos_cells.v
+SIM ?= icarus
+COCOTB_HDL_TIMEUNIT      = 1ns
+COCOTB_HDL_TIMEPRECISION = 10ps

--- a/sim/functional/mesh_wh_xy_noc/Makefile
+++ b/sim/functional/mesh_wh_xy_noc/Makefile
@@ -1,8 +1,4 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-SRCS_DIR=$(shell git rev-parse --show-toplevel)/srcs
+include ../common.mk
 SWITCH_VER_DIR=$(SRCS_DIR)/switch
 COMPONENT_VER_DIR=$(SRCS_DIR)/components
 NOC_VER_DIR=$(SRCS_DIR)/noc
@@ -27,15 +23,13 @@ VERILOG_SOURCES += $(SWITCH_VER_DIR)/mesh_wormhole/mesh_wormhole_node.v
 VERILOG_SOURCES += $(NOC_VER_DIR)/mesh_wormhole_xy_noc.v
 
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(NOC_VER_DIR)/mesh_wormhole_xy_noc_synth.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/mesh_wormhole_xy_noc-netlist.v
 endif
-
 
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL  := tb
 MODULE    := test
-SIM       ?= icarus
 
 export ROW_N                ?= 3
 export COL_M                ?= 3
@@ -45,9 +39,6 @@ export NODE_RADIX           ?= 5
 export NODE_BUFFER_DEPTH_W  ?= 2
 export ARB_TYPE             ?= 0
 export CLK_PERIOD           ?= 10
-
-COCOTB_HDL_TIMEUNIT       = 1ns
-COCOTB_HDL_TIMEPRECISION  = 10ps
 
 VERILOG_SOURCES += ./tb.sv
 COMPILE_ARGS += -P $(TOPLEVEL).ROW_N=$(ROW_N)

--- a/sim/functional/mesh_wh_xy_noc/Makefile
+++ b/sim/functional/mesh_wh_xy_noc/Makefile
@@ -23,7 +23,7 @@ VERILOG_SOURCES += $(SWITCH_VER_DIR)/mesh_wormhole/mesh_wormhole_node.v
 VERILOG_SOURCES += $(NOC_VER_DIR)/mesh_wormhole_xy_noc.v
 
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES = $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/mesh_wormhole_xy_noc-netlist.v
 endif
 

--- a/sim/functional/mesh_wormhole_switch/Makefile
+++ b/sim/functional/mesh_wormhole_switch/Makefile
@@ -1,31 +1,26 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-SRC_DIR=$(shell git rev-parse --show-toplevel)/srcs
+include ../common.mk
 
 # files
-VERILOG_SOURCES = $(SRC_DIR)/switch/constants.v
-VERILOG_SOURCES += $(SRC_DIR)/components/circ_fifo.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/matrix_arbiter.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/round_robin.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/arbiters/static_priority_arbiter.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/allocators/allocator.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/routers/xy_router.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/virtual_channels/virtual_channel.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/crossbars/nxn_parrallel_crossbar.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/mesh_wormhole/mesh_wormhole_node.v
+VERILOG_SOURCES = $(SRCS_DIR)/switch/constants.v
+VERILOG_SOURCES += $(SRCS_DIR)/components/circ_fifo.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/arbiters/matrix_arbiter.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/arbiters/round_robin.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/arbiters/static_priority_arbiter.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/allocators/allocator.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/routers/xy_router.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/virtual_channels/virtual_channel.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/crossbars/nxn_parrallel_crossbar.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/mesh_wormhole/mesh_wormhole_node.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(SRC_DIR)/switch/constants.v
-  VERILOG_SOURCES += $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(SRC_DIR)/switch/mesh_wormhole/mesh_wormhole_node_synth.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/mesh_wormhole_node-netlist.v
 endif
 VERILOG_SOURCES += ./tb.sv
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL := tb
 MODULE   := test
-SIM      ?= icarus
 
+export CLK_PERIOD     ?= 10
 # Depending on the Simulator we want to choose different sets of arguments to pass
 export IN_N           ?= 5 # 1
 export OUT_M          ?= 5 # 2
@@ -37,8 +32,6 @@ export FLIT_ID_W      ?= 2 # 7
 export FLIT_DATA_W    ?= 8 # 8
 export BUFFER_DEPTH_W ?= 2 # 9
 export ARB_TYPE       ?= 0 # 10
-
-export CLK_PERIOD     ?= 10
 
 ifeq ($(SIM), icarus)
   COMPILE_ARGS += -P $(TOPLEVEL).IN_N=$(IN_N)                      # 1

--- a/sim/functional/mesh_wormhole_switch/Makefile
+++ b/sim/functional/mesh_wormhole_switch/Makefile
@@ -12,7 +12,8 @@ VERILOG_SOURCES += $(SRCS_DIR)/switch/virtual_channels/virtual_channel.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/crossbars/nxn_parrallel_crossbar.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/mesh_wormhole/mesh_wormhole_node.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(CMOS_CELLS)
+	VERILOG_SOURCES = $(SRCS_DIR)/switch/constants.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/mesh_wormhole_node-netlist.v
 endif
 VERILOG_SOURCES += ./tb.sv

--- a/sim/functional/mesh_wormhole_switch/Makefile
+++ b/sim/functional/mesh_wormhole_switch/Makefile
@@ -12,7 +12,7 @@ VERILOG_SOURCES += $(SRCS_DIR)/switch/virtual_channels/virtual_channel.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/crossbars/nxn_parrallel_crossbar.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/mesh_wormhole/mesh_wormhole_node.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES = $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/mesh_wormhole_node-netlist.v
 endif
 VERILOG_SOURCES += ./tb.sv

--- a/sim/functional/mesh_xy_noc/Makefile
+++ b/sim/functional/mesh_xy_noc/Makefile
@@ -1,9 +1,6 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-SWITCH_VER_DIR=$(shell git rev-parse --show-toplevel)/srcs/switch/
-NOC_VER_DIR=$(shell git rev-parse --show-toplevel)/srcs/noc
+include ../common.mk
+SWITCH_VER_DIR=$(SRCS_DIR)/switch
+NOC_VER_DIR=$(SRCS_DIR)/noc
 
 export DEBUG_ATTACH ?=0
 export TESTFACTORY ?=0
@@ -24,14 +21,13 @@ VERILOG_SOURCES += $(SWITCH_VER_DIR)/routers/xy_router.v
 VERILOG_SOURCES += $(SWITCH_VER_DIR)/../components/circ_fifo.v
 VERILOG_SOURCES += $(NOC_VER_DIR)/mesh_xy_noc.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(NOC_VER_DIR)/mesh_xy_noc_synth.v
+  VERILOG_SOURCES = $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/mesh_xy_noc-netlist.v
 endif
-
+VERILOG_SOURCES += ./tb.sv
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL := tb
 MODULE   := test
-SIM      ?= icarus
 
 export ROW_N        ?= 4
 export COL_M        ?= 4
@@ -43,8 +39,6 @@ export ARB_TYPE     ?= 0
 export CLK_PERIOD        ?= 10
 COCOTB_HDL_TIMEUNIT      = 1ns
 COCOTB_HDL_TIMEPRECISION = 1ps
-
-VERILOG_SOURCES += ./tb.sv
 
 COMPILE_ARGS += -P $(TOPLEVEL).ROW_N=$(ROW_N)
 COMPILE_ARGS += -P $(TOPLEVEL).COL_M=$(COL_M)

--- a/sim/functional/utils/rav.py
+++ b/sim/functional/utils/rav.py
@@ -16,8 +16,7 @@ def simulate(log, tf, ps, synth, parameters, tcl_script):
         log.debug(f"ReSynthesize! {tcl_script}")
         os.chdir(f"{git_root}/synth")
 
-        synth_cmd = [f"{git_root}/synth/yosys_wrapper.sh", f"-sf", f"{tcl_script}",
-                     "--no-xdot"]
+        synth_cmd = [f"{git_root}/synth/yosys_wrapper.sh", f"-sf", f"{tcl_script}"]
         for arg in parameters.items():
             synth_cmd.append(f"{arg[0]}={arg[1]}")
 

--- a/sim/functional/virtual_channel/Makefile
+++ b/sim/functional/virtual_channel/Makefile
@@ -6,7 +6,8 @@ VERILOG_SOURCES += $(SRCS_DIR)/components/circ_fifo.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/routers/xy_router.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/virtual_channels/virtual_channel.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(CMOS_CELLS)
+	VERILOG_SOURCES = $(SRCS_DIR)/switch/constants.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/virtual_channel-netlist.v
 endif
 VERILOG_SOURCES+= ./tb.v

--- a/sim/functional/virtual_channel/Makefile
+++ b/sim/functional/virtual_channel/Makefile
@@ -6,7 +6,7 @@ VERILOG_SOURCES += $(SRCS_DIR)/components/circ_fifo.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/routers/xy_router.v
 VERILOG_SOURCES += $(SRCS_DIR)/switch/virtual_channels/virtual_channel.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES = $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/virtual_channel-netlist.v
 endif
 VERILOG_SOURCES+= ./tb.v

--- a/sim/functional/virtual_channel/Makefile
+++ b/sim/functional/virtual_channel/Makefile
@@ -1,24 +1,18 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-SRC_DIR=$(shell git rev-parse --show-toplevel)/srcs/
+include ../common.mk
 
 # files
-VERILOG_SOURCES = $(SRC_DIR)/switch/constants.v
-VERILOG_SOURCES += $(SRC_DIR)/components/circ_fifo.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/routers/xy_router.v
-VERILOG_SOURCES += $(SRC_DIR)/switch/virtual_channels/virtual_channel.v
+VERILOG_SOURCES = $(SRCS_DIR)/switch/constants.v
+VERILOG_SOURCES += $(SRCS_DIR)/components/circ_fifo.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/routers/xy_router.v
+VERILOG_SOURCES += $(SRCS_DIR)/switch/virtual_channels/virtual_channel.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(SRC_DIR)/switch/constants.v
-  VERILOG_SOURCES += $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(SRC_DIR)/switch/virtual_channels/virtual_channel_synth.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/virtual_channel-netlist.v
 endif
 VERILOG_SOURCES+= ./tb.v
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL := tb
 MODULE   := test
-SIM      ?= icarus
 
 # Depending on the Simulator we want to choose different sets of arguments to pass
 export VC_DEPTH_W   ?= 2

--- a/sim/functional/xy_switch/Makefile
+++ b/sim/functional/xy_switch/Makefile
@@ -1,8 +1,5 @@
-export PYTHON_BIN=/usr/bin/python3
-export SHELL=/bin/bash
-
-export TOPLEVEL_LANG ?= verilog
-VER_DIR=$(shell git rev-parse --show-toplevel)/srcs/switch
+include ../common.mk
+VER_DIR=$(SRCS_DIR)/switch
 
 export DEBUG_ATTACH ?=0
 export TESTFACTORY ?=0
@@ -20,17 +17,14 @@ VERILOG_SOURCES += $(VER_DIR)/arbiters/static_priority_arbiter.v
 VERILOG_SOURCES += $(VER_DIR)/crossbars/nxn_single_crossbar.v
 VERILOG_SOURCES += $(VER_DIR)/routers/xy_router.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(VER_DIR)/constants.v
-  VERILOG_SOURCES += $(shell git rev-parse --show-toplevel)/synth/cmos_cells.v
-  VERILOG_SOURCES += $(VER_DIR)/simple_mesh_xy/xy_synth.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES += $(SYNTH_DIR)/xy_router-netlist.v
 endif
-
 VERILOG_SOURCES += ./tb.v
 
 # Specifies essentials of the DUT and the cocotb TB
 TOPLEVEL := tb
 MODULE   := test
-SIM      ?= icarus
 
 export PORT_N            ?= 5
 export COL_CORD          ?= 1
@@ -43,8 +37,6 @@ export PACKET_W          ?= $(PCKT_W_calc)
 export IN_FIFO_DEPTH_W   ?= 2
 export ARB_TYPE          ?= 0
 
-COCOTB_HDL_TIMEUNIT      = 1ns
-COCOTB_HDL_TIMEPRECISION = 1ps
 #COMPILE_ARGS+= -m /usr/local/libexec/covered.vpi covered_vpi.v
 COMPILE_ARGS += -P $(TOPLEVEL).PORT_N=$(PORT_N)
 COMPILE_ARGS += -P $(TOPLEVEL).COL_CORD=$(COL_CORD)

--- a/sim/functional/xy_switch/Makefile
+++ b/sim/functional/xy_switch/Makefile
@@ -17,7 +17,8 @@ VERILOG_SOURCES += $(VER_DIR)/arbiters/static_priority_arbiter.v
 VERILOG_SOURCES += $(VER_DIR)/crossbars/nxn_single_crossbar.v
 VERILOG_SOURCES += $(VER_DIR)/routers/xy_router.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES = $(CMOS_CELLS)
+	VERILOG_SOURCES = $(SRCS_DIR)/switch/constants.v
+  VERILOG_SOURCES += $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/xy_router-netlist.v
 endif
 VERILOG_SOURCES += ./tb.v

--- a/sim/functional/xy_switch/Makefile
+++ b/sim/functional/xy_switch/Makefile
@@ -17,7 +17,7 @@ VERILOG_SOURCES += $(VER_DIR)/arbiters/static_priority_arbiter.v
 VERILOG_SOURCES += $(VER_DIR)/crossbars/nxn_single_crossbar.v
 VERILOG_SOURCES += $(VER_DIR)/routers/xy_router.v
 ifeq ($(SYNTH), 1)
-  VERILOG_SOURCES += $(CMOS_CELLS)
+  VERILOG_SOURCES = $(CMOS_CELLS)
   VERILOG_SOURCES += $(SYNTH_DIR)/xy_router-netlist.v
 endif
 VERILOG_SOURCES += ./tb.v

--- a/srcs/components/circ_fifo.v
+++ b/srcs/components/circ_fifo.v
@@ -9,13 +9,8 @@
 
 module circ_fifo
   #(
-    `ifdef YS_FIFO_TOP
-    parameter DATA_W        = `YS_DATA_W,
-    parameter FIFO_DEPTH_W  = `YS_FIFO_DEPTH_W,
-    `else
     parameter DATA_W        = 8,
     parameter FIFO_DEPTH_W  = 2,
-    `endif
     parameter ID            = 0
     )
   (

--- a/srcs/noc/mesh_wormhole_xy_noc.v
+++ b/srcs/noc/mesh_wormhole_xy_noc.v
@@ -25,24 +25,14 @@
 `define RIGHT 3
 `define DOWN  4
 
-module mesh_wormhole_xy_noc#(
-  `ifdef YS_MESH_WH_XY_TOP
-    parameter ROW_N               = `YS_ROW_N,
-    parameter COL_M               = `YS_COL_M,
-    parameter NODE_RADIX          = `YS_NODE_RADIX, // CONSTANT
-    parameter CHANNEL_W           = `YS_CHANNEL_W,
-    parameter FLIT_ID_W           = `YS_FLIT_ID_W,
-    parameter NODE_BUFFER_DEPTH_W = `YS_NODE_BUFFER_DEPTH_W,
-    parameter ARB_TYPE            = `YS_ARB_TYPE
-  `else
-    parameter ROW_N               = 3,
-    parameter COL_M               = 3,
-    parameter NODE_RADIX          = 5, // CONSTANT
-    parameter CHANNEL_W           = 8,
-    parameter FLIT_ID_W           = 2, // HEAD, BODY, TAIL, NULL(not defined), CONSTANT
-    parameter NODE_BUFFER_DEPTH_W = 4,
-    parameter ARB_TYPE            = 0
-  `endif
+module mesh_wormhole_xy_noc #(
+  parameter ROW_N               = 3,
+  parameter COL_M               = 3,
+  parameter NODE_RADIX          = 5, // CONSTANT
+  parameter CHANNEL_W           = 8,
+  parameter FLIT_ID_W           = 2, // HEAD, BODY, TAIL, NULL(not defined), CONSTANT
+  parameter NODE_BUFFER_DEPTH_W = 4,
+  parameter ARB_TYPE            = 0
   ) (
     // GLOBAL
     input                           clk_i,

--- a/srcs/noc/mesh_xy_noc.v
+++ b/srcs/noc/mesh_xy_noc.v
@@ -27,19 +27,11 @@
 
 module mesh_xy_noc
   # (
-      `ifdef YS_MESH_XY_TOP
-      parameter ROW_N         = `YS_ROW_N,
-      parameter COL_M         = `YS_COL_M,
-      parameter PCKT_DATA_W   = `YS_PCKT_DATA_W,
-      parameter FIFO_DEPTH_W  = `YS_FIFO_DEPTH_W,
-      parameter ARB_TYPE      = `YS_ARB_TYPE,
-      `else
       parameter ROW_N         = 3,
       parameter COL_M         = 3,
       parameter PCKT_DATA_W   = 8,
       parameter FIFO_DEPTH_W  = 3,
       parameter ARB_TYPE      = 0
-      `endif
       )
     (
       input clk_i,

--- a/srcs/switch/allocators/allocator.v
+++ b/srcs/switch/allocators/allocator.v
@@ -58,19 +58,11 @@
 */
 `timescale 1ns / 1ps
 module allocator #(
-  `ifdef YS_ALLOCATOR_TOP
-    parameter IN_N        = `YS_IN_N,
-    parameter OUT_M       = `YS_OUT_M,
-    parameter FLIT_ID_W   = `YS_FLIT_ID_W,
-    parameter OUT_CHAN_ID = `YS_OUT_CHAN_ID,
-    parameter ARB_TYPE    = `YS_ARB_TYPE
-  `else
     parameter IN_N        = 5,  // to specify from how many inputs we should choose
     parameter OUT_M       = 5,  // for route result inputs
     parameter FLIT_ID_W   = 2,  // how many bits are taken for ID in each FLIT
     parameter OUT_CHAN_ID = 0,  // which output channel is this Alloc assigned to
     parameter ARB_TYPE    = 0   // what type of arbitration should be used (0 - matrix, 1 - round robin, 2 - static_priority)
-  `endif
   ) (
     input                           clk_i,
     input                           rst_ni,
@@ -172,7 +164,7 @@ module allocator #(
       );
     end
     else begin
-      initial $error("Wrong Arbitration Type, possible options 0,1,2"); 
+      initial $error("Wrong Arbitration Type, possible options 0,1,2");
     end
   endgenerate
 

--- a/srcs/switch/arbiters/hop_cnt_arbiter.v
+++ b/srcs/switch/arbiters/hop_cnt_arbiter.v
@@ -26,13 +26,8 @@
 `timescale 1ns / 1ps
 module hop_cnt_arbiter
   #(
-    `ifdef YS_HOP_CNT_ARB_TOP
-    parameter IN_N      = `YS_IN_N,
-    parameter HOP_CNT_W = `YS_HOP_CNT_W
-    `else
     parameter IN_N      = 5,
     parameter HOP_CNT_W = 3
-    `endif
     )
   ( input   [IN_N-1:0]                vld_input_i,
     input   [(IN_N*HOP_CNT_W)-1 : 0]  hop_cnt_i,

--- a/srcs/switch/crossbars/nxn_parrallel_crossbar.v
+++ b/srcs/switch/crossbars/nxn_parrallel_crossbar.v
@@ -12,15 +12,9 @@
 `timescale 1ns / 1ps
 module nxn_parrallel_crossbar
   #(
-    `ifdef YS_NXN_PARRALLEL_CROSSBAR_TOP
-    parameter DATA_W  = `YS_DATA_W,
-    parameter IN_N    = `YS_IN_N,
-    parameter OUT_M   = `YS_OUT_M
-    `else
     parameter DATA_W  = 10, //(2 bits for flit ID, 8 bits for the flit payload)
     parameter IN_N    = 5,
     parameter OUT_M   = 5
-    `endif
     )
   ( //N inputs N outputs
     input   [(IN_N*DATA_W)-1:0]         data_i, // data from input channels

--- a/srcs/switch/crossbars/nxn_single_crossbar.v
+++ b/srcs/switch/crossbars/nxn_single_crossbar.v
@@ -14,13 +14,8 @@
 `timescale 1ns / 1ps
 module nxn_single_crossbar
 # (
-    `ifdef YS_NXN_SINGLE_CROSSBAR_TOP
-    parameter DATA_W = `YS_DATA_W,
-    parameter PORT_N = `YS_PORT_N,
-    `else
     parameter DATA_W = 8,
     parameter PORT_N = 5
-    `endif
     )
   (
     input   [(PORT_N * DATA_W) - 1 : 0] data_i,

--- a/srcs/switch/mesh_wormhole/mesh_wormhole_node.v
+++ b/srcs/switch/mesh_wormhole/mesh_wormhole_node.v
@@ -16,18 +16,6 @@
 */
 `timescale 1ns / 1ps
 module mesh_wormhole_node #(
-  `ifdef YS_MESH_WORMHOLE_NODE_TOP
-    parameter IN_N            = `YS_IN_N,
-    parameter OUT_M           = `YS_OUT_M,
-    parameter FLIT_DATA_W     = `YS_FLIT_DATA_W,
-    parameter FLIT_ID_W       = `YS_FLIT_ID_W,
-    parameter ROW_ADDR_W      = `YS_ROW_ADDR_W,
-    parameter COL_ADDR_W      = `YS_COL_ADDR_W,
-    parameter ROW_CORD        = `YS_ROW_CORD,
-    parameter COL_CORD        = `YS_COL_CORD,
-    parameter BUFFER_DEPTH_W  = `YS_BUFFER_DEPTH_W,
-    parameter ARB_TYPE        = `YS_ARB_TYPE
-  `else
     parameter IN_N            = 5,
     parameter OUT_M           = 5,
     parameter FLIT_DATA_W     = 8,
@@ -38,7 +26,6 @@ module mesh_wormhole_node #(
     parameter COL_CORD        = 1,
     parameter BUFFER_DEPTH_W  = 2,
     parameter ARB_TYPE        = 0
-  `endif
   ) (
     input clk_i,
     input rst_ni,

--- a/srcs/switch/routers/xy_router.v
+++ b/srcs/switch/routers/xy_router.v
@@ -12,19 +12,11 @@
 `timescale 1ns / 1ps
 module xy_router
 # (
-    `ifdef YS_ROUTER_TOP
-    parameter COL_CORD    = `YS_COL_CORD,
-    parameter ROW_CORD    = `YS_ROW_CORD,
-    parameter COL_ADDR_W  = `YS_COL_ADDR_W,
-    parameter ROW_ADDR_W  = `YS_ROW_ADDR_W,
-    parameter OUT_N_W     = `YS_OUT_N_W
-    `else
     parameter COL_CORD    = 4'd0,
     parameter ROW_CORD    = 4'd0,
     parameter COL_ADDR_W  = 4,
     parameter ROW_ADDR_W  = 4,
     parameter OUT_N_W     = 3
-    `endif
     )
   (
     input  [COL_ADDR_W-1 : 0]  col_addr_i,

--- a/srcs/switch/simple_mesh_xy/xy_switch.v
+++ b/srcs/switch/simple_mesh_xy/xy_switch.v
@@ -38,25 +38,14 @@
 `timescale 1ns / 1ps
 module xy_switch
 # (
-    `ifdef YS_XY_SW_TOP // only For YOSYS parameter setting (it's not possible to override parameters for singular modules)
-      parameter COL_CORD      = `YS_COL_CORD,
-      parameter ROW_CORD      = `YS_ROW_CORD,
-      parameter PORT_N        = `YS_PORT_N, // 1 is minimum because of connection to RESOURCE,
-      parameter FIFO_DEPTH_W  = `YS_FIFO_DEPTH_W,
-      parameter COL_ADDR_W    = `YS_COL_ADDR_W,
-      parameter ROW_ADDR_W    = `YS_ROW_ADDR_W,
-      parameter PCKT_DATA_W   = `YS_PCKT_DATA_W,
-      parameter ARB_TYPE      = `YS_ARB_TYPE,
-    `else
-      parameter COL_CORD      = 0,
-      parameter ROW_CORD      = 0,
-      parameter PORT_N        = 5, // 1 is minimum because of connection to RESOURCE,
-      parameter FIFO_DEPTH_W  = 3,
-      parameter COL_ADDR_W    = 4,
-      parameter ROW_ADDR_W    = 4,
-      parameter PCKT_DATA_W   = 8,
-      parameter ARB_TYPE      = 0,
-    `endif
+    parameter COL_CORD      = 0,
+    parameter ROW_CORD      = 0,
+    parameter PORT_N        = 5, // 1 is minimum because of connection to RESOURCE,
+    parameter FIFO_DEPTH_W  = 3,
+    parameter COL_ADDR_W    = 4,
+    parameter ROW_ADDR_W    = 4,
+    parameter PCKT_DATA_W   = 8,
+    parameter ARB_TYPE      = 0,
     parameter PCKT_W = COL_ADDR_W + ROW_ADDR_W + PCKT_DATA_W
     )
   (
@@ -163,7 +152,7 @@ module xy_switch
         );
       end
       else begin
-        initial $error("Wrong Arbitration Type, possible options 0,1,2");   
+        initial $error("Wrong Arbitration Type, possible options 0,1,2");
       end
     endgenerate
 

--- a/synth/.gitignore
+++ b/synth/.gitignore
@@ -1,3 +1,4 @@
 json_files
 dot_files
 logs
+*-netlist*

--- a/synth/allocator.tcl
+++ b/synth/allocator.tcl
@@ -1,67 +1,27 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-read_verilog -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
-read_verilog -sv -defer ../srcs/switch/arbiters/round_robin.v
-read_verilog -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
-
+set src ../srcs
 set top_module allocator
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) IN_N
-set params(1) OUT_M
-set params(2) FLIT_ID_W
-set params(3) OUT_CHAN_ID
-set params(4) ARB_TYPE
 
-#default values for synth
-set values(0) 5
-set values(1) 5
-set values(2) 2
-set values(3) 1
-# ARB TYPE 
-# 0 - matrix, 1 round robin 2 static
-set values(4) 1
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  IN_N 5
+  OUT_M 5
+  FLIT_ID_W 2
+  OUT_CHAN_ID 1
+  ARB_TYPE 0
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/allocators/allocator.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  switch/constants.v
+  switch/arbiters/matrix_arbiter.v
+  switch/arbiters/round_robin.v
+  switch/arbiters/static_priority_arbiter.v
+  switch/allocators/allocator.v
 }
 
-read_verilog -sv -DYS_ALLOCATOR_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              -DYS_$params(3)=$values(3) \
-              -DYS_$params(4)=$values(4) \
-              ../srcs/switch/allocators/allocator.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0)-$values(1)-$values(2)-$values(3).json
-write_verilog ../srcs/switch/allocators/allocator_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/common.tcl
+++ b/synth/common.tcl
@@ -1,0 +1,45 @@
+#!/usr/bin/tclsh
+# Common backend for synth + opt + report for yosys
+set std_lib $::env(STD_LIB)
+
+# Read Verilog part
+for { set idx 0 }  { $idx < [llength $files] - 1 }  { incr idx } {
+  read_verilog -sv -defer $src/[lindex $files $idx]
+}
+read_verilog -sv $src/[lindex $files [expr [llength $files] - 1]]
+
+log "SCRIPT_INFO: Parameters and their values:"
+foreach name [array names params] {
+  if { [info exists ::env($name)] } {
+    set params($name) $::env($name)
+  }
+  log "SCRIPT_INFO: $name = $params($name)"
+}
+
+# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
+# it also shows params and values lists of parameters that are modifiable and their default values
+if {$::env(SHOW_PARAMS) == 1} {
+  chparam -list
+  exit 0
+}
+
+# Set parameter values
+puts "Set parameters"
+foreach name [array names params] {
+  chparam -set $name $params($name) $top_module
+}
+
+hierarchy -top $top_module -keep_portwidths -check
+synth -top $top_module -flatten
+dfflibmap -liberty $std_lib
+abc -liberty $std_lib
+clean
+
+if { [info exists ::env(XDOT)] } {
+  show -enum -long -width -signed -stretch $top_module
+}
+
+json -o $::env(JSON_PATH)/$top_module.json
+write_verilog ./$top_module-netlist.v
+
+stat -top $top_module -liberty $std_lib -tech cmos

--- a/synth/fifo_synth.tcl
+++ b/synth/fifo_synth.tcl
@@ -1,54 +1,20 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-
+set src ../srcs
 set top_module circ_fifo
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) FIFO_DEPTH_W
-set params(1) DATA_W
 
-#default values for synth
-set values(0) 4
-set values(1) 8
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  FIFO_DEPTH_W 4
+  DATA_W 8
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/components/circ_fifo.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  components/circ_fifo.v
 }
 
-read_verilog  -DYS_FIFO_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              ../srcs/components/circ_fifo.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0)-$values(1).json
-write_verilog ../srcs/components/circ_fifo_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/hop_cnt_arb.tcl
+++ b/synth/hop_cnt_arb.tcl
@@ -1,54 +1,21 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-
+set src ../srcs
 set top_module hop_cnt_arbiter
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) IN_N
-set params(1) HOP_CNT_W
 
-#default values for synth
-set values(0) 5
-set values(1) 4
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  IN_N 5
+  HOP_CNT_W 3
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog -sv ../srcs/switch/arbiters/hop_cnt_arbiter.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  switch/constants.v
+  switch/arbiters/hop_cnt_arbiter.v
 }
 
-read_verilog -sv -DYS_HOP_CNT_ARB_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              ../srcs/switch/arbiters/hop_cnt_arbiter.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0)-$values(1).json
-write_verilog ../srcs/switch/arbiters/hop_cnt_arbiter_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/matrix_arb.tcl
+++ b/synth/matrix_arb.tcl
@@ -1,48 +1,20 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -sv -defer ../srcs/switch/constants.v
-
+set src ../srcs
 set top_module matrix_arb
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) IN_N
 
-#default values for synth
-set values(0) 5
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  IN_N 5
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog -sv ../srcs/switch/arbiters/matrix_arbiter.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  switch/constants.v
+  switch/arbiters/matrix_arbiter.v
 }
 
-read_verilog -sv ../srcs/switch/arbiters/matrix_arbiter.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0).json
-write_verilog ../srcs/switch/arbiters/matrix_arbiter_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/mesh_wormhole_node.tcl
+++ b/synth/mesh_wormhole_node.tcl
@@ -1,91 +1,38 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
-
-read_verilog  -defer ../srcs/components/circ_fifo.v
-read_verilog  -defer ../srcs/switch/constants.v
-read_verilog  -defer ../srcs/switch/virtual_channels/virtual_channel.v
-read_verilog  -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
-read_verilog  -sv -defer ../srcs/switch/arbiters/round_robin.v
-read_verilog  -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
-read_verilog  -defer ../srcs/switch/arbiters/hop_cnt_arbiter.v
-read_verilog  -defer ../srcs/switch/routers/xy_router.v
-read_verilog  -defer ../srcs/switch/crossbars/nxn_parrallel_crossbar.v
-read_verilog  -defer ../srcs/switch/allocators/allocator.v
-
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set top_module mesh_wormhole_node
-# elaborate design hierarchy
-
-set params(0) ROW_CORD
-set params(1) COL_CORD
-set params(2) IN_N
-set params(3) OUT_M
-set params(4) COL_ADDR_W
-set params(5) ROW_ADDR_W
-set params(6) FLIT_ID_W
-set params(7) FLIT_DATA_W
-set params(8) BUFFER_DEPTH_W
-set params(9) ARB_TYPE
-
-set values(0) 1
-set values(1) 1
-set values(2) 5
-set values(3) 5
-set values(4) 2
-set values(5) 2
-set values(6) 2
-set values(7) 8
-set values(8) 2
-set values(9) 0
-
-chparam -list
-log "Parameters and their values:(after they were overriden with arguments)"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index) = $values($index)"
-}
-
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/mesh_wormhole/mesh_wormhole_node.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
-}
-
 echo on
 
-read_verilog -sv -DYS_MESH_WORMHOLE_NODE_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              -DYS_$params(3)=$values(3) \
-              -DYS_$params(4)=$values(4) \
-              -DYS_$params(5)=$values(5) \
-              -DYS_$params(6)=$values(6) \
-              -DYS_$params(7)=$values(7) \
-              -DYS_$params(8)=$values(8) \
-              -DYS_$params(9)=$values(9) \
-              ../srcs/switch/mesh_wormhole/mesh_wormhole_node.v
+set src ../srcs
+set top_module mesh_wormhole_node
 
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show -enum -width -colors 3 -stretch $top_module
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  ROW_CORD 1
+  COL_CORD 1
+  IN_N 5
+  OUT_M 5
+  COL_ADDR_W 2
+  ROW_ADDR_W 2
+  FLIT_ID_W 2
+  FLIT_DATA_W 8
+  BUFFER_DEPTH_W 2
+  ARB_TYPE 0
 }
 
-json -o $::env(JSON_PATH)/$top_module.json
-write_verilog ../srcs/switch/mesh_wormhole/mesh_wormhole_node_synth.v
+# File list
+set files {
+  components/circ_fifo.v
+  switch/constants.v
+  switch/arbiters/hop_cnt_arbiter.v
+  switch/virtual_channels/virtual_channel.v
+  switch/arbiters/matrix_arbiter.v
+  switch/arbiters/round_robin.v
+  switch/arbiters/static_priority_arbiter.v
+  switch/routers/xy_router.v
+  switch/crossbars/nxn_parrallel_crossbar.v
+  switch/allocators/allocator.v
+  switch/mesh_wormhole/mesh_wormhole_node.v
+}
 
-stat -top $top_module -liberty $std_lib -tech cmos
-ltp
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/mesh_xy_noc.tcl
+++ b/synth/mesh_xy_noc.tcl
@@ -1,77 +1,33 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-read_verilog -defer ../srcs/components/circ_fifo.v
-read_verilog -defer ../srcs/switch/simple_mesh_xy/switch_constants.v
-read_verilog -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
-read_verilog -sv -defer ../srcs/switch/arbiters/round_robin.v
-read_verilog -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
-read_verilog -defer ../srcs/switch/routers/xy_router.v
-read_verilog -defer ../srcs/switch/crossbars/nxn_single_crossbar.v
-read_verilog -defer ../srcs/switch/simple_mesh_xy/control_unit.v
-read_verilog -defer ../srcs/switch/simple_mesh_xy/xy_switch.v
-
+set src ../srcs
 set top_module mesh_xy_noc
-# elaborate design hierarchy
 
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) ROW_N
-set params(1) COL_M
-set params(2) PCKT_DATA_W
-set params(3) FIFO_DEPTH_W
-set params(4) ARB_TYPE
-
-#default values for synth
-set values(0) 4
-set values(1) 4
-set values(2) 8
-set values(3) 4
-set values(4) 0
-
-chparam -list
-log "Parameters and their values:(after they were overriden with arguments)"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index) = $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  ROW_N 4
+  COL_M 4
+  PCKT_DATA_W 8
+  FIFO_DEPTH_W 4
+  ARB_TYPE 0
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/noc/mesh_xy_noc.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  switch/simple_mesh_xy/switch_constants.v
+  components/circ_fifo.v
+  switch/constants.v
+  switch/arbiters/matrix_arbiter.v
+  switch/arbiters/round_robin.v
+  switch/arbiters/static_priority_arbiter.v
+  switch/routers/xy_router.v
+  switch/crossbars/nxn_single_crossbar.v
+  switch/simple_mesh_xy/control_unit.v
+  switch/simple_mesh_xy/xy_switch.v
+  noc/mesh_xy_noc.v
 }
 
-set file_name $top_module-$values(0)-$values(1)-$values(2)-$values(3)
-
-echo on
-read_verilog  -DYS_MESH_XY_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              -DYS_$params(3)=$values(3) \
-              -DYS_$params(4)=$values(4) \
-              ../srcs/noc/mesh_xy_noc.v
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$file_name.json
-write_verilog ../srcs/noc/mesh_xy_noc_synth.v
-echo on
-tee -o $file_name.log stat -top $top_module -liberty $std_lib -tech cmos
-ltp
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/nxn_parrallel_crossbar.tcl
+++ b/synth/nxn_parrallel_crossbar.tcl
@@ -20,6 +20,3 @@ set files {
 
 # Executes the basic backend for synth + opt + report
 source common.tcl
-
-yosys -import
-set std_lib $::env(STD_LIB)

--- a/synth/nxn_parrallel_crossbar.tcl
+++ b/synth/nxn_parrallel_crossbar.tcl
@@ -1,57 +1,25 @@
+#!/usr/bin/tclsh
+yosys -import
+echo on
+
+set src ../srcs
+set top_module nxn_parrallel_crossbar
+
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  DATA_W 10
+  IN_N 5
+  OUT_M 5
+}
+
+# File list
+set files {
+  switch/constants.v
+  switch/crossbars/nxn_parrallel_crossbar.v
+}
+
+# Executes the basic backend for synth + opt + report
+source common.tcl
+
 yosys -import
 set std_lib $::env(STD_LIB)
-
-read_verilog -defer ../srcs/switch/constants.v
-
-set top_module nxn_parrallel_crossbar
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) DATA_W
-set params(1) IN_N
-set params(2) OUT_M
-
-#default values for synth
-set values(0) 10
-set values(1) 5
-set values(2) 5
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
-}
-
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/crossbars/nxn_parrallel_crossbar.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
-}
-
-read_verilog  -DYS_NXN_PARRALLEL_CROSSBAR_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              ../srcs/switch/crossbars/nxn_parrallel_crossbar.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0)-$values(1).json
-write_verilog ../srcs/switch/crossbars/nxn_parrallel_crossbar_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos

--- a/synth/nxn_single_crossbar.tcl
+++ b/synth/nxn_single_crossbar.tcl
@@ -1,54 +1,21 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-
+set src ../srcs
 set top_module nxn_single_crossbar
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) DATA_W
-set params(1) PORT_N
 
-#default values for synth
-set values(0) 10
-set values(1) 5
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  DATA_W 10
+  PORT_N 5
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/crossbars/nxn_single_crossbar.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  switch/constants.v
+  switch/crossbars/nxn_single_crossbar.v
 }
 
-read_verilog  -DYS_NXN_SINGLE_CROSSBAR_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              ../srcs/switch/crossbars/nxn_single_crossbar.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0)-$values(1).json
-write_verilog ../srcs/switch/crossbars/nxn_single_crossbar_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/router_synth.tcl
+++ b/synth/router_synth.tcl
@@ -1,67 +1,25 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
-
-read_verilog -defer ../srcs/switch/constants.v
-
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set top_module xy_router
-# elaborate design hierarchy
-
-#TOP module param names when running with YOSYS
-set params(0) ROW_CORD
-set params(1) COL_CORD
-set params(2) OUT_N_W
-set params(3) COL_ADDR_W
-set params(4) ROW_ADDR_W
-
-#default values for synth
-set values(0) 1
-set values(1) 1
-set values(2) 3
-set values(3) 3
-set values(4) 3
-
-chparam -list
-log "Parameters and their values:(after they were overriden with arguments)"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index) = $values($index)"
-}
-
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/routers/xy_router.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
-}
-
 echo on
-read_verilog  -DYS_ROUTER_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              -DYS_$params(3)=$values(3) \
-              -DYS_$params(4)=$values(4) \
-              ../srcs/switch/routers/xy_router.v
 
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
+set src ../srcs
+set top_module xy_router
 
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  ROW_CORD 1
+  COL_CORD 1
+  OUT_N_W 3
+  COL_ADDR_W 3
+  ROW_ADDR_W 3
 }
 
-json -o $::env(JSON_PATH)/$top_module.json
-write_verilog ../srcs/switch/simple_mesh_xy/rtr_synth.v
+# File list
+set files {
+  components/circ_fifo.v
+  switch/constants.v
+  switch/routers/xy_router.v
+}
 
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/static_arb.tcl
+++ b/synth/static_arb.tcl
@@ -1,50 +1,20 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-
+set src ../srcs
 set top_module static_priority_arbiter
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) IN_N
 
-#default values for synth
-set values(0) 5
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  IN_N 5
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog -sv ../srcs/switch/arbiters/static_priority_arbiter.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  switch/constants.v
+  switch/arbiters/static_priority_arbiter.v
 }
 
-read_verilog -sv -DYS_STATIC_PRIORITY_ARBITER_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              ../srcs/switch/arbiters/static_priority_arbiter.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0).json
-write_verilog ../srcs/switch/arbiters/static_priority_arbiter_synth.v
-
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/sw_xy_synth.tcl
+++ b/synth/sw_xy_synth.tcl
@@ -1,89 +1,35 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
-
-read_verilog  -defer ../srcs/switch/constants.v
-read_verilog  -defer ../srcs/components/circ_fifo.v
-read_verilog  -defer ../srcs/switch/simple_mesh_xy/switch_constants.v
-read_verilog  -sv -defer ../srcs/switch/arbiters/static_priority_arbiter.v
-read_verilog  -sv -defer ../srcs/switch/arbiters/matrix_arbiter.v
-read_verilog  -sv -defer ../srcs/switch/arbiters/round_robin.v
-read_verilog  -defer ../srcs/switch/routers/xy_router.v
-read_verilog  -defer ../srcs/switch/crossbars/nxn_single_crossbar.v
-read_verilog  -defer ../srcs/switch/simple_mesh_xy/control_unit.v
-
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set top_module xy_switch
-# elaborate design hierarchy
-
-set params(0) ROW_CORD
-set params(1) COL_CORD
-set params(2) PORT_N
-set params(3) FIFO_DEPTH_W
-set params(4) COL_ADDR_W
-set params(5) ROW_ADDR_W
-set params(6) PCKT_DATA_W
-set params(7) ARB_TYPE
-
-set values(0) 1
-set values(1) 1
-
-set values(2) 5
-
-set values(3) 2
-
-set values(4) 2
-set values(5) 2
-
-set values(6) 64
-
-set values(7) 0
-
-chparam -list
-log "Parameters and their values:(after they were overriden with arguments)"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index) = $values($index)"
-}
-
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/simple_mesh_xy/xy_switch.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
-}
-
 echo on
 
-read_verilog  -DYS_XY_SW_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              -DYS_$params(3)=$values(3) \
-              -DYS_$params(4)=$values(4) \
-              -DYS_$params(5)=$values(5) \
-              -DYS_$params(6)=$values(6) \
-              -DYS_$params(7)=$values(7) \
-              ../srcs/switch/simple_mesh_xy/xy_switch.v
+set src ../srcs
+set top_module xy_switch
 
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  ROW_CORD 1
+  COL_CORD 1
+  PORT_N 5
+  FIFO_DEPTH_W 2
+  COL_ADDR_W 2
+  ROW_ADDR_W 2
+  PCKT_DATA_W 64
+  ARB_TYPE 0
 }
 
-json -o $::env(JSON_PATH)/$top_module.json
-write_verilog ../srcs/switch/simple_mesh_xy/xy_synth.v
+# File list
+set files {
+  switch/constants.v
+  components/circ_fifo.v
+  switch/simple_mesh_xy/switch_constants.v
+  switch/arbiters/matrix_arbiter.v
+  switch/arbiters/round_robin.v
+  switch/arbiters/static_priority_arbiter.v
+  switch/routers/xy_router.v
+  switch/crossbars/nxn_single_crossbar.v
+  switch/simple_mesh_xy/control_unit.v
+  switch/simple_mesh_xy/xy_switch.v
+}
 
-stat -top $top_module -liberty $std_lib -tech cmos
-ltp
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/virtual_channel.tcl
+++ b/synth/virtual_channel.tcl
@@ -1,73 +1,29 @@
+#!/usr/bin/tclsh
 yosys -import
-set std_lib $::env(STD_LIB)
+echo on
 
-read_verilog -defer ../srcs/switch/constants.v
-read_verilog -defer ../srcs/components/circ_fifo.v
-read_verilog -defer ../srcs/switch/routers/xy_router.v
-
+set src ../srcs
 set top_module virtual_channel
-# Set parameter values (values taken from EnvVars set by yosys_wrapper.sh)
-set params(0) VC_DEPTH_W
-set params(1) FLIT_DATA_W
-set params(2) FLIT_ID_W
-set params(3) ROW_CORD
-set params(4) COL_CORD
-set params(5) OUT_N_W
-set params(6) ROW_ADDR_W
-set params(7) COL_ADDR_W
 
-#default values for synth
-set values(0) 2
-set values(1) 8
-set values(2) 2
-set values(3) 1
-set values(4) 1
-set values(5) 3
-set values(6) 2
-set values(7) 2
-
-chparam -list
-log "Parameters and their values:"
-for { set index 0 }  { $index < [array size params] }  { incr index } {
-   if { [info exists ::env($params($index))] } {
-     set values($index) $::env($params($index))
-   }
-   log "$index. : $params($index)= $values($index)"
+# Define parameter names + values (values taken from EnvVars set by yosys_wrapper.sh)
+array set params {
+  VC_DEPTH_W 2
+  FLIT_DATA_W 8
+  FLIT_ID_W 2
+  ROW_CORD 1
+  COL_CORD 1
+  OUT_N_W 3
+  ROW_ADDR_W 2
+  COL_ADDR_W 2
 }
 
-# IF SHOW_PARAMS is set to 1, it only specifies what the TOPMODULE parameters are
-# it also shows params and values lists of parameters that are modifiable and their default values
-if {$::env(SHOW_PARAMS) == 1} {
-  read_verilog ../srcs/switch/virtual_channels/virtual_channel.v
-  log "Parameters from the top-module"
-  chparam -list
-  exit 0
+# File list
+set files {
+  components/circ_fifo.v
+  switch/constants.v
+  switch/routers/xy_router.v
+  switch/virtual_channels/virtual_channel.v
 }
 
-read_verilog  -DYS_VC_TOP=1 \
-              -DYS_$params(0)=$values(0) \
-              -DYS_$params(1)=$values(1) \
-              -DYS_$params(2)=$values(2) \
-              -DYS_$params(3)=$values(3) \
-              -DYS_$params(4)=$values(4) \
-              -DYS_$params(5)=$values(5) \
-              -DYS_$params(6)=$values(6) \
-              -DYS_$params(7)=$values(7) \
-              ../srcs/switch/virtual_channels/virtual_channel.v
-
-echo off
-hierarchy -top $top_module -keep_portwidths -check
-synth -top $top_module -flatten
-dfflibmap -liberty $std_lib
-abc -liberty $std_lib
-
-# cleanup
-clean
-
-if { ![info exists ::env(NO_XDOT)] } {
-  show  -enum -width -colors 3 $top_module
-}
-
-json -o $::env(JSON_PATH)/$top_module-$values(0)-$values(1).json
-write_verilog ../srcs/switch/virtual_channels/virtual_channel_synth.v
-stat -top $top_module -liberty $std_lib -tech cmos
+# Executes the basic backend for synth + opt + report
+source common.tcl

--- a/synth/yosys_wrapper.sh
+++ b/synth/yosys_wrapper.sh
@@ -29,7 +29,7 @@ function display_help {
   echo ">>"
   echo ">>            --show-params     - presents the parameters of the top module only (no synthesis)"
   echo ">>"
-  echo ">>            --no-xdot         - disables yosys show command"
+  echo ">>            --xdot            - enables yosys show command"
   echo ">>"
   echo ">>            --std-lib         - path to std cell library, default: std_libs/osu018_std.lib"
   echo ">>"
@@ -70,9 +70,9 @@ do
       export SHOW_PARAMS=1
       shift # past argument
       ;;
-      --no-xdot)
-      echo "${green}Setting NO_XDOT=1${white}"
-      export NO_XDOT=1
+      --xdot)
+      echo "${green}Setting XDOT=1${white}"
+      export XDOT=1
       shift # past argument
       ;;
       --std-lib)
@@ -116,7 +116,6 @@ yosys -tl $synth_log_name $SCRIPT_FILE || error_func $script_name
 
 if [[ -e ~/.yosys_show.dot ]]; then
   #statements
-
   if [[ ! -d $repo_path/synth/dot_files ]]; then
     #statements
     mkdir $repo_path/synth/dot_files


### PR DESCRIPTION
Yosys Wrapper + common.tcl (same structure as the cdc repo).

Improvements:
- cleaner way of defining files that go into the synth
- cleaner way of defining module parameter values
- XDOT view is disabled by default

Additionally:
- small Makefile rework through addition of `sim/functional/common.mk`